### PR TITLE
allow_nfsd new param

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -434,7 +434,7 @@ class IOCConfiguration:
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '30'
+        version = '31'
 
         return version
 
@@ -916,6 +916,10 @@ class IOCConfiguration:
         if not conf.get('allow_mount_linprocfs'):
             conf['allow_mount_linprocfs'] = 0
 
+        # Version 31 key
+        if not conf.get('allow_nfsd'):
+            conf['allow_nfsd'] = 0
+
         if not default:
             conf.update(jail_conf)
 
@@ -1183,6 +1187,7 @@ class IOCConfiguration:
             'allow_socket_af': 0,
             'allow_tun': 0,
             'allow_vmm': 0,
+            'allow_nfsd': 0,
             'cpuset': 'off',
             'rlimits': 'off',
             'memoryuse': 'off',
@@ -1354,6 +1359,7 @@ class IOCJson(IOCConfiguration):
         'allow_raw_sockets',
         'allow_sysvipc',
         'allow_set_hostname',
+        'allow_nfsd',
         'mount_fdescfs',
         'mount_devfs',
         'ip6_saddrsel',
@@ -2105,6 +2111,7 @@ class IOCJson(IOCConfiguration):
             "allow_quotas": truth_variations,
             "allow_socket_af": truth_variations,
             "allow_vmm": truth_variations,
+            "allow_nfsd": truth_variations,
             "vnet_interfaces": ("string", ),
             # RCTL limits
             "cpuset": ('string',),

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -134,6 +134,7 @@ class IOCStart(object):
         allow_sysvipc = self.conf["allow_sysvipc"]
         allow_raw_sockets = self.conf["allow_raw_sockets"]
         allow_chflags = self.conf["allow_chflags"]
+        allow_nfsd = self.conf["allow_nfsd"]
         allow_mlock = self.conf["allow_mlock"]
         allow_mount = self.conf["allow_mount"]
         allow_mount_devfs = self.conf["allow_mount_devfs"]
@@ -367,6 +368,12 @@ class IOCStart(object):
             _allow_vmm = f"allow.vmm={allow_vmm}"
             _exec_created = f'exec.created={exec_created}'
 
+        # FreeBSD < 13.3 does not support nfsd in jail
+        if userland_version < 13.3:
+            _allow_nfsd = ''
+        else:
+            _allow_nfsd = f"allow.nfsd={allow_nfsd}"
+
         if nat:
             self.log.debug(f'Checking NAT backend: {nat_backend}')
             self.__check_nat__(backend=nat_backend)
@@ -545,7 +552,7 @@ class IOCStart(object):
 
         parameters = [
             fdescfs, _allow_mlock, tmpfs,
-            _allow_mount_fdescfs, _allow_mount_fusefs, _allow_vmm,
+            _allow_mount_fdescfs, _allow_mount_fusefs, _allow_vmm, _allow_nfsd,
             f"allow.set_hostname={allow_set_hostname}",
             f"mount.devfs={mount_devfs}",
             f"allow.raw_sockets={allow_raw_sockets}",


### PR DESCRIPTION
fix #5

- Allow use of new allow.nfsd parameter with iocage's `allow_nfsd=1`
