### PR TITLE
Remove dependency on six

### DIFF
--- a/iocage_lib/utils.py
+++ b/iocage_lib/utils.py
@@ -1,5 +1,3 @@
-import six
-
 from ctypes import CDLL
 from ctypes.util import find_library
 
@@ -20,6 +18,6 @@ def load_ctypes_library(name, signatures):
 
 
 def ensure_unicode_str(value):
-    if not isinstance(value, six.text_type):
+    if not isinstance(value, str):
         value = value.decode()
     return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ coloredlogs>=9.0
 netifaces>=0.10.8
 GitPython>=2.1.11
 dnspython>=1.15.0
-six>=1.15.0
 jsonschema>=3.2.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'GitPython>=2.1.11',
         'netifaces>=0.10.8',
         'dnspython>=1.15.0',
-        'six>=1.15.0',
         'jsonschema>=3.2.0'
     ],
     entry_points={'console_scripts': ['iocage = iocage_lib:cli']},


### PR DESCRIPTION
I noticed that the Python 3.11 iocage-devel package has a missing dependency on`six`. Given it's only used in one place, and for compatibility with Python 2 which is no longer supported, remove it.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
