### PR TITLE
Replace usages of `list.insert(0, ...)`

### DIFF
--- a/iocage_cli/df.py
+++ b/iocage_cli/df.py
@@ -60,10 +60,10 @@ def cli(header, _long, _sort):
     jail_list.sort(key=sort)
 
     if header:
-        jail_list.insert(0, ["NAME", "CRT", "RES", "QTA", "USE", "AVA"])
+        table.header(["NAME", "CRT", "RES", "QTA", "USE", "AVA"])
         # We get an infinite float otherwise.
         table.set_cols_dtype(["t", "t", "t", "t", "t", "t"])
-        table.add_rows(jail_list)
+        table.add_rows(jail_list, header=False)
 
         ioc_common.logit({"level": "INFO", "message": table.draw()})
     else:

--- a/iocage_cli/snaplist.py
+++ b/iocage_cli/snaplist.py
@@ -43,10 +43,10 @@ def cli(header, jail, _long, _sort):
     snap_list = ioc.IOCage(jail=jail).snap_list(_long, _sort)
 
     if header:
-        snap_list.insert(0, ["NAME", "CREATED", "RSIZE", "USED"])
+        table.header(["NAME", "CREATED", "RSIZE", "USED"])
         # We get an infinite float otherwise.
         table.set_cols_dtype(["t", "t", "t", "t"])
-        table.add_rows(snap_list)
+        table.add_rows(snap_list, header=False)
         ioc_common.logit({
             "level"  : "INFO",
             "message": table.draw()

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -487,19 +487,16 @@ def sort_release(releases, split=False, fetch_releases=False):
                     pass
 
     ordered_r_dict = collections.OrderedDict(sorted(r_dict.items()))
-    index = 0
 
     for r, t in ordered_r_dict.items():
         if split:
             r = r.rsplit('_')[0]  # Remove the enumeration
             if t:
-                release_list.insert(index, [f"{r}-{t}"])
+                release_list.append([f"{r}-{t}"])
             else:
-                release_list.insert(index, [r])
-            index += 1
+                release_list.append([r])
         else:
-            release_list.insert(index, f"{r}-{t}")
-            index += 1
+            release_list.append(f"{r}-{t}")
 
     return release_list
 

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -543,9 +543,8 @@ class IOCFstab(object):
 
         # We get an infinite float otherwise.
         table.set_cols_dtype(["t", "t"])
-        flat_fstab.insert(0, ["INDEX", "FSTAB ENTRY"])
-
-        table.add_rows(flat_fstab)
+        table.header(["INDEX", "FSTAB ENTRY"])
+        table.add_rows(flat_fstab, header=False)
 
         return table.draw()
 

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -178,9 +178,8 @@ class IOCList(object):
 
         # We get an infinite float otherwise.
         table.set_cols_dtype(["t", "t"])
-        jail_list.insert(0, ["NAME", "IP4"])
-
-        table.add_rows(jail_list)
+        table.header(["NAME", "IP4"])
+        table.add_rows(jail_list, header=False)
 
         return table.draw()
 
@@ -443,23 +442,21 @@ class IOCList(object):
                 table.set_cols_dtype(["t", "t", "t", "t", "t", "t", "t", "t",
                                       "t", "t", "t"])
 
-                jail_list.insert(0, ["JID", "NAME", "BOOT", "STATE", "TYPE",
-                                     "RELEASE", "IP4", "IP6", "TEMPLATE",
-                                     "PORTAL", "DOC_URL"])
+                table.header(["JID", "NAME", "BOOT", "STATE", "TYPE", "RELEASE",
+                              "IP4", "IP6", "TEMPLATE", "PORTAL", "DOC_URL"])
             else:
                 # We get an infinite float otherwise.
                 table.set_cols_dtype(["t", "t", "t", "t", "t", "t", "t", "t",
                                       "t", "t"])
 
-                jail_list.insert(0, ["JID", "NAME", "BOOT", "STATE", "TYPE",
-                                     "RELEASE", "IP4", "IP6", "TEMPLATE",
-                                     'BASEJAIL'])
+                table.header(["JID", "NAME", "BOOT", "STATE", "TYPE", "RELEASE",
+                              "IP4", "IP6", "TEMPLATE", 'BASEJAIL'])
         else:
             # We get an infinite float otherwise.
             table.set_cols_dtype(["t", "t", "t", "t", "t"])
-            jail_list.insert(0, ["JID", "NAME", "STATE", "RELEASE", "IP4"])
+            table.header(["JID", "NAME", "STATE", "RELEASE", "IP4"])
 
-        table.add_rows(jail_list)
+        table.add_rows(jail_list, header=False)
 
         return table.draw()
 
@@ -474,8 +471,8 @@ class IOCList(object):
 
             return flat_base
 
-        base_list.insert(0, ["Bases fetched"])
-        table.add_rows(base_list)
+        table.header(["Bases fetched"])
+        table.add_rows(base_list, header=False)
         # We get an infinite float otherwise.
         table.set_cols_dtype(["t"])
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -975,9 +975,9 @@ fingerprint: {fingerprint}
                     )
                     for p in plugin_list
                 ]
-                plugin_list.insert(0, list_header)
 
-                table.add_rows(plugin_list)
+                table.header(list_header)
+                table.add_rows(plugin_list, header=False)
 
                 return table.draw()
 


### PR DESCRIPTION
Hello!

In my pursuit of deepening knowledge about `FreeBSD jails`, a lot of people and books point to `iocage` as the way to go, so I checked the project. While doing so, I noticed usages of `list.insert(0, ...)`, which is a Python footgun, because despite the name, Python lists are more like arrays with optimized appends, not prepends, so such call incurs an O(n) runtime penalty.

I decided to grep the codebase for `.insert(` method calls and fix them in this pull request.

---

Remaining usages:

```
$ rg '\.insert\(' --glob='*.py'
doc/source/conf.py
21:sys.path.insert(0, os.path.abspath('.'))

tests/conftest.py
262:        cmd.insert(0, 'iocage')

iocage_lib/ioc_start.py
1753:                    rules.insert(1, f'{final_line}{rdrs}')
1763:                rules.insert(1, nat_rule)
```

were inspected and do not pose any trouble.

---

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
