### PR TITLE
Implement ALL target for snapshot, snaplist and snapremove

### DIFF
--- a/doc/source/advanced-use.rst
+++ b/doc/source/advanced-use.rst
@@ -158,6 +158,8 @@ Snapshots are point-in-time copies of data, a safety point to which a
 jail can be reverted at any time. Initially, snapshots take up almost no
 space, as only changing data is recorded.
 
+You may use **ALL** as a target jail name for these commands if you want to target all jails at once.
+
 List snapshots for a jail:
 
 :command:`iocage snaplist [UUID|NAME]`
@@ -167,6 +169,18 @@ Create a new snapshot:
 :command:`iocage snapshot [UUID|NAME]`
 
 This creates a snapshot based on the current time.
+
+:command:`iocage snapshot [UUID|NAME] -n [SNAPSHOT NAME]`
+
+This creates a snapshot with the given name.
+
+Delete a snapshot:
+
+:command:`iocage snapremove [UUID|NAME] -n [SNAPSHOT NAME]`
+
+Delete all snapshots from a jail (requires `-f / --force`):
+
+:command:`iocage snapremove [UUID|NAME] -n ALL -f`
 
 .. index:: Resource Limits
 .. _Resource Limits:

--- a/iocage_cli/snaplist.py
+++ b/iocage_cli/snaplist.py
@@ -43,9 +43,14 @@ def cli(header, jail, _long, _sort):
     snap_list = ioc.IOCage(jail=jail).snap_list(_long, _sort)
 
     if header:
-        table.header(["NAME", "CREATED", "RSIZE", "USED"])
+        if jail == 'ALL':
+            cols = ["JAIL"]
+        else:
+            cols = []
+        cols.extend(["NAME", "CREATED", "RSIZE", "USED"])
+        table.header(cols)
         # We get an infinite float otherwise.
-        table.set_cols_dtype(["t", "t", "t", "t"])
+        table.set_cols_dtype(["t"]*len(cols))
         table.add_rows(snap_list, header=False)
         ioc_common.logit({
             "level"  : "INFO",

--- a/iocage_cli/snapremove.py
+++ b/iocage_cli/snapremove.py
@@ -25,6 +25,7 @@
 
 import click
 
+import iocage_lib.ioc_common as ioc_common
 import iocage_lib.iocage as ioc
 
 
@@ -32,6 +33,15 @@ import iocage_lib.iocage as ioc
 @click.argument("jail")
 @click.option("--name", "-n", help="The snapshot name. This will be what comes"
                                    " after @", required=True)
-def cli(jail, name):
+@click.option("--force", "-f", is_flag=True, default=False,
+    help="Force removal (required for -n ALL)")
+def cli(jail, name, force):
     """Removes a snapshot from a user supplied jail."""
-    ioc.IOCage(jail=jail).snap_remove(name)
+    if name == 'ALL' and not force:
+        ioc_common.logit({
+                    "level": "EXCEPTION",
+                    "message": 'Usage: iocage snapremove [OPTIONS] JAILS...\n'
+                               '\nError: Mass snapshot deletion requires "force" (-f).'
+                })
+    skip_jails = jail != 'ALL'
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).snap_remove(name)

--- a/iocage_cli/snapshot.py
+++ b/iocage_cli/snapshot.py
@@ -36,4 +36,5 @@ __rootcmd__ = True
                                    " after @", required=False)
 def cli(jail, name):
     """Snapshot a jail."""
-    ioc.IOCage(jail=jail, skip_jails=True).snapshot(name)
+    skip_jails = jail != 'ALL'
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).snapshot(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,12 @@ def jail():
 
 
 @pytest.fixture
+def snapshot():
+    from tests.data_classes import Snapshot
+    return Snapshot
+
+
+@pytest.fixture
 def resource_selector():
     from tests.data_classes import ResourceSelector
     return ResourceSelector()

--- a/tests/data_classes.py
+++ b/tests/data_classes.py
@@ -27,7 +27,7 @@ class Row:
         for attr in [
             'name', 'jid', 'state', 'release', 'ip4', 'ip6', 'orig_release',
             'boot', 'type', 'template', 'basejail', 'crt', 'res', 'qta',
-            'use', 'ava', 'created', 'rsize', 'used', 'orig_name'
+            'use', 'ava', 'created', 'rsize', 'used', 'orig_name', 'jail'
         ]:
             setattr(self, attr, None)
 
@@ -268,6 +268,10 @@ class Row:
         self.name, self.created, self.rsize, self.used = self.standard_parse()
 
 
+    def snapall_parse(self):
+        self.jail, self.name, self.created, self.rsize, self.used = self.standard_parse()
+
+
 class ZFS:
     # TODO: Improve how we manage zfs object here
     pool = None
@@ -361,12 +365,24 @@ class Resource:
     DEFAULT_JSON_FILE = 'config.json'
 
     def __init__(self, name, zfs=None):
-        self.name = name
-        self.zfs = ZFS() if not zfs else zfs
+        super().__setattr__('name', name)
+        super().__setattr__('zfs', ZFS() if not zfs else zfs)
         assert isinstance(self.zfs, ZFS) is True
 
+    def __eq__(self, other):
+        return self.name == other.name
+    
+    def __hash__(self):
+        return hash(self.name)
+    
     def __repr__(self):
         return self.name
+
+    def __setattr__(self, name, attr_value):
+        raise AttributeError(f"Resources are immutable. Cannot set attribute '{name}'.")
+
+    def __delattr__(self, name):
+        raise AttributeError(f"Resources are immutable. Cannot delete attribute '{name}'.")
 
     def convert_to_row(self, **kwargs):
         raise NotImplemented
@@ -376,12 +392,12 @@ class Snapshot(Resource):
 
     def __init__(self, name, parent_dataset, zfs=None):
         super().__init__(name, zfs)
-        self.parent = parent_dataset
+        object.__setattr__(self, 'parent', parent_dataset)
         if isinstance(self.parent, str):
-            self.parent = Jail(self.parent)
+            object.__setattr__(self, 'parent', Jail(self.parent))
         if self.exists:
             for k, v in self.zfs.get_snapshot_safely(self.name).items():
-                setattr(self, k, v)
+                object.__setattr__(self, k, v)
 
     @property
     def exists(self):
@@ -625,7 +641,7 @@ class Jail(Resource):
     @property
     def is_cloned(self):
         return bool(
-            self.jail_dataset[
+            self.root_dataset[
                 'properties'
             ].get('origin', {}).get('value')
         )
@@ -795,3 +811,20 @@ class ResourceSelector:
         return [
             j for j in self.all_jails if j.config.get(key, None) == value
         ]
+
+    @property
+    def cloned_snapshots_set(self):
+        cloned_jails = self.cloned_jails
+        origins = {
+            jail.root_dataset['properties']['origin']['value']
+            for jail in cloned_jails
+        }
+        origins |= {
+            jail.jail_dataset['properties']['origin']['value']
+            for jail in cloned_jails
+        }
+        origins -= { "" }
+        return {
+            Snapshot(origin, origin.rsplit('@', 1)[0])
+            for origin in origins
+        }

--- a/tests/functional_tests/0018_snapshot_test.py
+++ b/tests/functional_tests/0018_snapshot_test.py
@@ -30,6 +30,7 @@ require_zpool = pytest.mark.require_zpool
 
 
 SNAP_NAME = 'snaptest'
+SNAPALL_NAME = 'snapalltest'
 
 
 def common_function(invoke_cli, jails, skip_test):
@@ -44,6 +45,20 @@ def common_function(invoke_cli, jails, skip_test):
     assert [
         s.id.split('@')[1] for s in jail.recursive_snapshots
     ].count(SNAP_NAME) >= 2
+
+
+def all_jails_function(invoke_cli, jails, skip_test):
+    skip_test(not jails)
+
+    invoke_cli(
+        ['snapshot', 'ALL', '-n', SNAPALL_NAME]
+    )
+
+    for jail in jails:
+        # We use count because of template and cloned jails
+        assert [
+            s.id.split('@')[1] for s in jail.recursive_snapshots
+        ].count(SNAPALL_NAME) >= 2
 
 
 @require_root
@@ -66,3 +81,9 @@ def test_02_snapshot_of_template_jail(invoke_cli, resource_selector, skip_test):
 @require_zpool
 def test_03_snapshot_of_cloned_jail(invoke_cli, resource_selector, skip_test):
     common_function(invoke_cli, resource_selector.cloned_jails, skip_test)
+
+
+@require_root
+@require_zpool
+def test_04_snapshot_of_all_jails(invoke_cli, resource_selector, skip_test):
+    all_jails_function(invoke_cli, resource_selector.all_jails, skip_test)

--- a/tests/functional_tests/0019_list_snapshot_test.py
+++ b/tests/functional_tests/0019_list_snapshot_test.py
@@ -37,7 +37,7 @@ def common_function(
     jails_as_rows, full=False
 ):
     for flag in SORTING_FLAGS:
-        if type(jail) is list:
+        if isinstance(jail, list):
             command = ['snaplist', 'ALL', '-s', flag]
         else:
             command = ['snaplist', jail.name, '-s', flag]
@@ -48,7 +48,7 @@ def common_function(
             command
         )
 
-        if type(jail) is list:
+        if isinstance(jail, list):
             jails = jail
             orig_list = parse_rows_output(result.output, 'snapall')
             verify_list = []


### PR DESCRIPTION
Hello,

Okay so this is a proposal to close #18.

It brings:
- `iocage snaplist ALL` to list snapshots from all jails at once
- `iocage snapshot ALL -n <name>` to take a snapshot of all jails at once, with a common name. Intended for mass backup, upgrade or migration scenarios.
- `iocage snapremove ALL -n <name>` to remove such a common snapshot from all jails.
- `iocage snapremove <jail> -n ALL -f` to remove all snapshots from a jail. It requires `-f` or `--force`.
- These last two can be combined into `iocage snapremove ALL -n ALL -f` to remove all snapshots from all jails.

I provided some tests for all these features and an update for the documentation.

----

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
