### PR TITLE
Enable use of a prefix in the zfs tree used by iocage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,11 @@ iocage_tests_task:
     - pkg
   install_iocage_script:
     - python3 setup.py install
-  test_script: pytest --zpool=pool tests/functional_tests --junit-xml=reports/pytest-report.xml -rA --image
+  matrix:
+    - name: No prefix
+      test_script: pytest -rA --zpool=pool tests/functional_tests --junit-xml=reports/pytest-report.xml --image
+    - name: Custom prefix
+      test_script: pytest -rA --zpool=pool --prefix=test-prefix tests/functional_tests --junit-xml=reports/pytest-report.xml --image
   always:
     pytest_results_artifacts:
       path: reports/*.xml

--- a/doc/source/advanced-use.rst
+++ b/doc/source/advanced-use.rst
@@ -158,6 +158,8 @@ Snapshots are point-in-time copies of data, a safety point to which a
 jail can be reverted at any time. Initially, snapshots take up almost no
 space, as only changing data is recorded.
 
+You may use **ALL** as a target jail name for these commands if you want to target all jails at once.
+
 List snapshots for a jail:
 
 :command:`iocage snaplist [UUID|NAME]`
@@ -167,6 +169,18 @@ Create a new snapshot:
 :command:`iocage snapshot [UUID|NAME]`
 
 This creates a snapshot based on the current time.
+
+:command:`iocage snapshot [UUID|NAME] -n [SNAPSHOT NAME]`
+
+This creates a snapshot with the given name.
+
+Delete a snapshot:
+
+:command:`iocage snapremove [UUID|NAME] -n [SNAPSHOT NAME]`
+
+Delete all snapshots from a jail (requires `-f / --force`):
+
+:command:`iocage snapremove [UUID|NAME] -n ALL -f`
 
 .. index:: Resource Limits
 .. _Resource Limits:

--- a/iocage_cli/activate.py
+++ b/iocage_cli/activate.py
@@ -31,12 +31,22 @@ __rootcmd__ = True
 
 
 @click.command(name="activate", help="Set a zpool active for iocage usage.")
+@click.option(
+    "--prefix", "-p", default='',
+    help="Provide a prefix for dataset path."
+)
 @click.argument("zpool")
-def cli(zpool):
+def cli(zpool, prefix):
     """Calls ZFS set to change the property org.freebsd.ioc:active to yes."""
-    ioc.IOCage(activate=True).activate(zpool)
+    ioc.IOCage(activate=True).activate(zpool, prefix)
 
     ioc_common.logit({
         "level"  : "INFO",
         "message": f"ZFS pool '{zpool}' successfully activated."
     })
+    
+    if prefix:
+      ioc_common.logit({
+              "level"  : "INFO",
+              "message": f"Dataset prefix '{prefix}' set."
+          })

--- a/iocage_cli/migrate.py
+++ b/iocage_cli/migrate.py
@@ -74,8 +74,8 @@ def cli(force, delete):
     for uuid, path in jails.items():
         pool = ioc_json.IOCJson().json_get_value("pool")
         iocroot = ioc_json.IOCJson(pool).json_get_value("iocroot")
-        jail = f"{pool}/iocage/jails/{uuid}"
-        jail_old = f"{pool}/iocage/jails_old/{uuid}"
+        jail = f"{iocroot}/jails/{uuid}"
+        jail_old = f"{iocroot}/jails_old/{uuid}"
         conf = ioc_json.IOCJson(path).json_get_value('all')
 
         try:
@@ -164,7 +164,7 @@ def cli(force, delete):
                 try:
                     su.check_call([
                         "zfs", "destroy", "-r", "-f",
-                        f"{pool}/iocage/jails_old"
+                        f"{iocroot}/jails_old"
                     ])
                 except su.CalledProcessError:
                     # We just want the top level dataset gone, no big deal.

--- a/iocage_cli/snaplist.py
+++ b/iocage_cli/snaplist.py
@@ -43,9 +43,14 @@ def cli(header, jail, _long, _sort):
     snap_list = ioc.IOCage(jail=jail).snap_list(_long, _sort)
 
     if header:
-        table.header(["NAME", "CREATED", "RSIZE", "USED"])
+        if jail == 'ALL':
+            cols = ["JAIL"]
+        else:
+            cols = []
+        cols.extend(["NAME", "CREATED", "RSIZE", "USED"])
+        table.header(cols)
         # We get an infinite float otherwise.
-        table.set_cols_dtype(["t", "t", "t", "t"])
+        table.set_cols_dtype(["t"]*len(cols))
         table.add_rows(snap_list, header=False)
         ioc_common.logit({
             "level"  : "INFO",

--- a/iocage_cli/snapremove.py
+++ b/iocage_cli/snapremove.py
@@ -25,6 +25,7 @@
 
 import click
 
+import iocage_lib.ioc_common as ioc_common
 import iocage_lib.iocage as ioc
 
 
@@ -32,6 +33,15 @@ import iocage_lib.iocage as ioc
 @click.argument("jail")
 @click.option("--name", "-n", help="The snapshot name. This will be what comes"
                                    " after @", required=True)
-def cli(jail, name):
+@click.option("--force", "-f", is_flag=True, default=False,
+    help="Force removal (required for -n ALL)")
+def cli(jail, name, force):
     """Removes a snapshot from a user supplied jail."""
-    ioc.IOCage(jail=jail).snap_remove(name)
+    if name == 'ALL' and not force:
+        ioc_common.logit({
+                    "level": "EXCEPTION",
+                    "message": 'Usage: iocage snapremove [OPTIONS] JAILS...\n'
+                               '\nError: Mass snapshot deletion requires "force" (-f).'
+                })
+    skip_jails = jail != 'ALL'
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).snap_remove(name)

--- a/iocage_cli/snapshot.py
+++ b/iocage_cli/snapshot.py
@@ -36,4 +36,5 @@ __rootcmd__ = True
                                    " after @", required=False)
 def cli(jail, name):
     """Snapshot a jail."""
-    ioc.IOCage(jail=jail, skip_jails=True).snapshot(name)
+    skip_jails = jail != 'ALL'
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).snapshot(name)

--- a/iocage_lib/ioc_clean.py
+++ b/iocage_lib/ioc_clean.py
@@ -27,8 +27,10 @@ import iocage_lib.ioc_common
 import iocage_lib.ioc_destroy
 import iocage_lib.ioc_json
 import shutil
+import os
 
 from iocage_lib.dataset import Dataset
+from iocage_lib.pools import Pool
 
 
 class IOCClean:
@@ -36,6 +38,7 @@ class IOCClean:
 
     def __init__(self, callback=None, silent=False):
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value('pool')
+        self.zpool = Pool(self.pool)
         self.iocroot = iocage_lib.ioc_json.IOCJson(self.pool).json_get_value(
             'iocroot')
 
@@ -52,7 +55,7 @@ class IOCClean:
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(
-            f'{self.pool}/iocage/jails',
+            f'{self.iocroot}/jails',
             clean=True
         )
 
@@ -66,7 +69,7 @@ class IOCClean:
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(
-            f'{self.pool}/iocage/download',
+            f'{self.iocroot}/download',
             clean=True
         )
 
@@ -78,7 +81,7 @@ class IOCClean:
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(
-            f'{self.pool}/iocage/releases',
+            f'{self.iocroot}/releases',
             clean=True)
 
     def clean_all(self):
@@ -96,7 +99,9 @@ class IOCClean:
                 silent=self.silent)
 
             iocage_lib.ioc_destroy.IOCDestroy().__destroy_parse_datasets__(
-                f'{self.pool}/{dataset}', clean=True)
+                os.path.join(self.zpool.name, self.zpool.prefix, dataset),
+                clean=True
+            )
 
     def clean_templates(self):
         """Cleans all templates and their respective children."""
@@ -108,7 +113,7 @@ class IOCClean:
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().__destroy_parse_datasets__(
-            f"{self.pool}/iocage/templates",
+            f"{self.iocroot}/templates",
             clean=True)
 
     def clean_images(self):
@@ -120,7 +125,7 @@ class IOCClean:
             _callback=self.callback,
             silent=self.silent)
 
-        Dataset(f'{self.pool}/iocage/images').destroy(True, True)
+        Dataset(f'{self.iocroot}/images').destroy(True, True)
 
     def clean_debug(self):
         """Removes the debug directory"""

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -43,6 +43,7 @@ import dns.exception
 import shutil
 
 from iocage_lib.cache import cache
+from iocage_lib.pools import Pool
 from iocage_lib.dataset import Dataset
 
 
@@ -59,6 +60,7 @@ class IOCCreate(object):
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(self.pool).json_get_value(
             "iocroot")
+        self.zpool = Pool(self.pool)
         self.release = release
         self.props = props
         self.num = num
@@ -218,10 +220,16 @@ class IOCCreate(object):
                 clone_etc_hosts = \
                     f"{self.iocroot}/jails/{jail_uuid}/root/etc/hosts"
 
-        jail = f"{self.pool}/iocage/jails/{jail_uuid}/root"
+        jail = os.path.join(
+            self.zpool.name, self.zpool.prefix, 'iocage',
+            'jails', jail_uuid, 'root'
+        )
 
         if self.template:
-            source = f'{self.pool}/iocage/templates/{self.release}@{jail_uuid}'
+            source = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'templates', f'{self.release}@{jail_uuid}'
+            )
             snap_cmd = ['zfs', 'snapshot', '-r', source]
 
             if self.thickjail:
@@ -255,7 +263,10 @@ class IOCCreate(object):
                 # Thick jails won't have this
                 pass
         elif self.clone:
-            source = f'{self.pool}/iocage/jails/{self.release}@{jail_uuid}'
+            source = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'jails', f'{self.release}@{jail_uuid}'
+            )
             snap_cmd = ['zfs', 'snapshot', '-r', source]
 
             if self.thickjail:
@@ -319,13 +330,16 @@ class IOCCreate(object):
                 config[k] = v
         else:
             if not self.empty:
-                dataset = f'{self.pool}/iocage/releases/{self.release}/' \
-                    f'root@{jail_uuid}'
+                dataset = os.path.join(
+                    self.zpool.name, self.zpool.prefix, 'iocage',
+                    'releases', self.release, f'root@{jail_uuid}'
+                )
                 try:
                     su.check_call(['zfs', 'snapshot', dataset], stderr=su.PIPE)
                 except su.CalledProcessError:
                     release = os.path.join(
-                        self.pool, 'iocage/releases', self.release
+                        self.zpool.name, self.zpool.prefix, 'iocage',
+                        'releases', self.release
                     )
                     if not Dataset(release).exists:
                         raise RuntimeError(
@@ -366,7 +380,11 @@ class IOCCreate(object):
         if jail_uuid == "default" or jail_uuid == "help":
             iocage_lib.ioc_destroy.IOCDestroy(
             ).__destroy_parse_datasets__(
-                f"{self.pool}/iocage/jails/{jail_uuid}")
+                os.path.join(
+                    self.zpool.name, self.zpool.prefix, 'iocage',
+                    'jails', jail_uuid
+                )
+            )
             iocage_lib.ioc_common.logit({
                 "level": "EXCEPTION",
                 "message": f"You cannot name a jail {jail_uuid}, "
@@ -391,7 +409,10 @@ class IOCCreate(object):
                 iocjson.json_set_value("type=template")
                 iocjson.json_set_value("template=1")
                 Dataset(
-                    os.path.join(self.pool, 'iocage', 'templates', jail_uuid)
+                    os.path.join(
+                        self.zpool.name, self.zpool.prefix, 'iocage',
+                        'templates', jail_uuid
+                    )
                 ).set_property('readonly', 'off')
 
                 # If you supply pkglist and templates without setting the
@@ -532,7 +553,10 @@ class IOCCreate(object):
         # If jail is template, the dataset would be readonly at this point
         if is_template:
             Dataset(
-                os.path.join(self.pool, 'iocage/templates', jail_uuid)
+                os.path.join(
+                    self.zpool.name, self.zpool.prefix, 'iocage',
+                    'templates', jail_uuid
+                )
             ).set_property('readonly', 'off')
 
         if self.empty:
@@ -691,7 +715,10 @@ class IOCCreate(object):
         if is_template:
             # We have to set readonly back, since we're done with our tasks
             Dataset(
-                os.path.join(self.pool, 'iocage/templates', jail_uuid)
+                os.path.join(
+                    self.zpool.name, self.zpool.prefix, 'iocage',
+                    'templates', jail_uuid
+                )
             ).set_property('readonly', 'on')
 
         return jail_uuid
@@ -1047,7 +1074,10 @@ ipv6_activate_all_interfaces=\"YES\"
                 ['umount', '-F', f'{location}/fstab', '-a']).communicate()
 
     def create_thickjail(self, jail_uuid, source):
-        jail = f"{self.pool}/iocage/jails/{jail_uuid}"
+        jail = os.path.join(
+            self.zpool.name, self.zpool.prefix, 'iocage',
+            'jails', jail_uuid
+        )
 
         try:
             su.Popen(['zfs', 'create', '-p', jail],

--- a/iocage_lib/ioc_debug.py
+++ b/iocage_lib/ioc_debug.py
@@ -30,7 +30,7 @@ import iocage_lib.ioc_json as ioc_json
 import iocage_lib.ioc_list as ioc_list
 
 from iocage_lib.dataset import Dataset
-from iocage_lib.pools import PoolListableResource
+from iocage_lib.pools import PoolListableResource, Pool
 
 
 class IOCDebug(object):
@@ -55,6 +55,7 @@ class IOCDebug(object):
 
     def __init__(self, path, silent=False, callback=None):
         self.pool = ioc_json.IOCJson(' ').json_get_value('pool')
+        self.zpool = Pool(self.pool)
         self.path = path
         self.callback = callback
         self.silent = silent
@@ -64,10 +65,14 @@ class IOCDebug(object):
         self.run_host_debug()
 
         jails = Dataset(
-            os.path.join(self.pool, 'iocage/jails')
+            os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage', 'jails'
+            )
         ).get_dependents()
         templates = Dataset(
-            os.path.join(self.pool, 'iocage/templates')
+            os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage', 'templates'
+            )
         ).get_dependents()
 
         for jail in jails:

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -45,7 +45,7 @@ class IOCDestroy:
         self.callback = callback
         self.iocroot_datasets = [
             d.name for d in
-            Dataset(os.path.join(self.pool, 'iocage')).get_dependents()
+            Dataset(self.iocroot).get_dependents()
         ]
         self.path = None
         self.j_conf = None
@@ -137,7 +137,7 @@ class IOCDestroy:
                 release = self.j_conf['release']
 
             release_snap = Snapshot(
-                f'{self.pool}/iocage/releases/{release}/root@{uuid}'
+                f'{self.iocroot}/releases/{release}/root@{uuid}'
             )
 
             if release_snap.exists:
@@ -146,7 +146,7 @@ class IOCDestroy:
                 try:
                     temp = self.j_conf['source_template']
                     temp_snap = Snapshot(
-                        f'{self.pool}/iocage/templates/{temp}@{uuid}'
+                        f'{self.iocroot}/templates/{temp}@{uuid}'
                     )
 
                     if temp_snap.exists:
@@ -182,7 +182,7 @@ class IOCDestroy:
                 uuid = dataset.rsplit('/', 1)[1]
 
             jail_datasets = Dataset(
-                f'{self.pool}/iocage/jails'
+                f'{self.iocroot}/jails'
             ).get_dependents()
             for jail in jail_datasets:
                 with iocage_lib.ioc_exceptions.ignore_exceptions(
@@ -278,7 +278,7 @@ class IOCDestroy:
 
         try:
             self.__destroy_parse_datasets__(
-                f"{self.pool}/iocage/{dataset_type}/{uuid}")
+                f"{self.iocroot}/{dataset_type}/{uuid}")
         except SystemExit:
             # The dataset doesn't exist, we don't care :)
             pass

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -238,7 +238,7 @@ class IOCFetch:
                     silent=self.silent)
 
             dataset = f"{self.iocroot}/download/{self.release}"
-            pool_dataset = f"{self.pool}/iocage/download/{self.release}"
+            pool_dataset = f"{self.iocroot}/download/{self.release}"
 
             if os.path.isdir(dataset):
                 pass
@@ -652,12 +652,15 @@ class IOCFetch:
 
     def fetch_download(self, _list, missing=False):
         """Creates the download dataset and then downloads the RELEASE."""
-        dataset = f"{self.iocroot}/download/{self.release}"
+        release_dir = f"{self.iocroot}/download/{self.release}"
         fresh = False
 
-        if not os.path.isdir(dataset):
+        if not os.path.isdir(release_dir):
             fresh = True
-            dataset = f"{self.pool}/iocage/download/{self.release}"
+            dataset = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'download', self.release
+            )
 
             ds = Dataset(dataset)
             if not ds.exists:
@@ -805,7 +808,10 @@ class IOCFetch:
         src = f"{self.iocroot}/download/{self.release}/{f}"
         dest = f"{self.iocroot}/releases/{self.release}/root"
 
-        dataset = f"{self.pool}/iocage/releases/{self.release}/root"
+        dataset = os.path.join(
+            self.zpool.name, self.zpool.prefix, 'iocage',
+            'releases', self.release, 'root'
+        )
 
         if not os.path.isdir(dest):
             self.zpool.create_dataset({

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -66,12 +66,12 @@ class IOCList(object):
     def list_datasets(self):
         """Lists the datasets of given type."""
         if self.list_type == "base":
-            ds = Dataset(f"{self.pool}/iocage/releases").get_dependents()
+            ds = Dataset(f"{self.iocroot}/releases").get_dependents()
         elif self.list_type == "template":
             ds = Dataset(
-                f"{self.pool}/iocage/templates").get_dependents()
+                f"{self.iocroot}/templates").get_dependents()
         else:
-            ds = Dataset(f"{self.pool}/iocage/jails").get_dependents()
+            ds = Dataset(f"{self.iocroot}/jails").get_dependents()
 
         ds = list(ds)
 
@@ -101,7 +101,7 @@ class IOCList(object):
                     )
 
             template_datasets = Dataset(
-                f'{self.pool}/iocage/templates').get_dependents()
+                f'{self.iocroot}/templates').get_dependents()
 
             for template in template_datasets:
                 uuid = template.name.rsplit("/", 1)[-1]

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -575,7 +575,7 @@ class IOCPlugin(object):
 
         jaildir = f"{self.iocroot}/jails/{self.jail}"
         repo_dir = f"{jaildir}/root/usr/local/etc/pkg/repos"
-        path = f"{self.pool}/iocage/jails/{self.jail}"
+        path = f"{self.iocroot}/jails/{self.jail}"
         _conf = iocage_lib.ioc_json.IOCJson(jaildir).json_get_value('all')
 
         # We do these tests again as the user could supply a malformed IP to
@@ -1464,7 +1464,7 @@ fingerprint: {fingerprint}
         names = [f'ioc_plugin_{name}_{self.date}', f'ioc_update_{release}']
 
         for snap in Dataset(
-            f'{self.pool}/iocage/jails/{self.jail}'
+            f'{self.iocroot}/jails/{self.jail}'
         ).snapshots_recursive():
             snap_name = snap.name
 

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -94,6 +94,7 @@ class IOCage:
         if not activate:
             self.generic_iocjson = ioc_json.IOCJson()
             self.pool = self.generic_iocjson.pool
+            self.zpool = Pool(self.pool)
             self.iocroot = self.generic_iocjson.iocroot
 
             if not skip_jails:
@@ -355,7 +356,7 @@ class IOCage:
 
         return stderr
 
-    def activate(self, zpool):
+    def activate(self, zpool, prefix=''):
         """Activates the zpool for iocage usage"""
         zpool = Pool(zpool, cache=False)
         if not zpool.exists:
@@ -372,8 +373,7 @@ class IOCage:
                 locked_error = None
                 if pool.root_dataset.locked:
                     locked_error = f'ZFS pool "{zpool}" root dataset is locked'
-
-                iocage_ds = Dataset(os.path.join(zpool.name, 'iocage'))
+                iocage_ds = Dataset(os.path.join(zpool.name, prefix, 'iocage'))
                 if iocage_ds.exists and iocage_ds.locked:
                     locked_error = f'ZFS dataset "{iocage_ds.name}" is locked'
                 if locked_error:
@@ -386,7 +386,7 @@ class IOCage:
                         silent=self.silent,
                     )
                 else:
-                    pool.activate_pool()
+                    pool.activate_pool(prefix)
             else:
                 pool.deactivate_pool()
 
@@ -633,7 +633,7 @@ class IOCage:
                 su.run(
                     [
                         'zfs', 'destroy', '-r',
-                        f'{self.pool}/iocage/jails/{clone}@{_uuid}'
+                        f'{self.iocroot}/jails/{clone}@{_uuid}'
                     ]
                 )
             raise
@@ -642,7 +642,7 @@ class IOCage:
 
     def destroy_release(self, download=False):
         """Destroy supplied RELEASE and the download dataset if asked"""
-        path = f"{self.pool}/iocage/releases/{self.jail}"
+        path = f"{self.iocroot}/releases/{self.jail}"
 
         release = Release(self.jail)
         # Let's make sure the release exists before we try to destroy it
@@ -663,7 +663,7 @@ class IOCage:
         ioc_destroy.IOCDestroy().__destroy_parse_datasets__(path, stop=False)
 
         if download:
-            path = f"{self.pool}/iocage/download/{self.jail}"
+            path = f"{self.iocroot}/download/{self.jail}"
             ioc_common.logit(
                 {
                     "level": "INFO",
@@ -688,7 +688,7 @@ class IOCage:
 
             if "Configuration is missing" in err:
                 uuid = err.split()[5]
-                path = f"{self.pool}/iocage/jails/{uuid}"
+                path = f"{self.iocroot}/jails/{uuid}"
 
                 if uuid == self.jail:
                     ioc_destroy.IOCDestroy().__destroy_parse_datasets__(
@@ -714,7 +714,7 @@ class IOCage:
         except FileNotFoundError as err:
             # Jail is lacking a configuration, time to nuke it from orbit.
             uuid = str(err).rsplit("/")[-2]
-            path = f"{self.pool}/iocage/jails/{uuid}"
+            path = f"{self.iocroot}/jails/{uuid}"
 
             if uuid == self.jail:
                 ioc_destroy.IOCDestroy().__destroy_parse_datasets__(path)
@@ -768,12 +768,12 @@ class IOCage:
 
         for jail, path in self.jails.items():
             conf = ioc_json.IOCJson(path).json_get_value('all')
-            mountpoint = f"{self.pool}/iocage/jails/{jail}"
+            mountpoint = f"{self.iocroot}/jails/{jail}"
 
             template = conf["type"]
 
             if template == "template":
-                mountpoint = f"{self.pool}/iocage/templates/{jail}"
+                mountpoint = f"{self.iocroot}/templates/{jail}"
 
             ds = Dataset(mountpoint)
             zconf = ds.properties
@@ -1394,8 +1394,11 @@ class IOCage:
                 _callback=self.callback,
                 silent=self.silent)
 
-        path = f"{self.pool}/iocage/{_folders[0]}/{uuid}"
-        new_path = f"{self.pool}/iocage/{_folders[0]}/{new_name}"
+        path = f"{self.iocroot}/{_folders[0]}/{uuid}"
+        new_path = os.path.join(
+            self.zpool.name, self.zpool.prefix, 'iocage',
+            _folders[0], new_name
+        )
 
         _silent = self.silent
         self.silent = True
@@ -1522,9 +1525,9 @@ class IOCage:
                 silent=self.silent)
 
         if ioc_common.check_truthy(conf['template']):
-            target = f"{self.pool}/iocage/templates/{uuid}"
+            target = f"{self.iocroot}/templates/{uuid}"
         else:
-            target = f"{self.pool}/iocage/jails/{uuid}"
+            target = f"{self.iocroot}/jails/{uuid}"
 
         dataset = Dataset(target)
         if not dataset.exists:
@@ -1671,9 +1674,9 @@ class IOCage:
         snap_list_root = []
 
         if ioc_common.check_truthy(conf['template']):
-            full_path = f"{self.pool}/iocage/templates/{uuid}"
+            full_path = f"{self.iocroot}/templates/{uuid}"
         else:
-            full_path = f"{self.pool}/iocage/jails/{uuid}"
+            full_path = f"{self.iocroot}/jails/{uuid}"
 
         dataset = Dataset(full_path)
 
@@ -1749,9 +1752,15 @@ class IOCage:
         conf = ioc_json.IOCJson(path, silent=self.silent).json_get_value('all')
 
         if ioc_common.check_truthy(conf['template']):
-            target = f"{self.pool}/iocage/templates/{uuid}"
+            target = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'templates', uuid
+            )
         else:
-            target = f"{self.pool}/iocage/jails/{uuid}"
+            target = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'jails', uuid
+            )
 
         snap = Snapshot(f'{target}@{name}')
         if snap.exists:
@@ -2190,7 +2199,9 @@ Remove the snapshot: ioc_upgrade_{_date} if everything is OK
         return {
                     d.properties.get('origin', "").replace('/root@', '@')
                     for d in Dataset(
-                        os.path.join(self.pool, 'iocage')
+                        os.path.join(
+                            self.zpool.name, self.zpool.prefix, 'iocage'
+                        )
                     ).get_dependents(depth=3)
                 }
 
@@ -2228,9 +2239,15 @@ Remove the snapshot: ioc_upgrade_{_date} if everything is OK
         conf = ioc_json.IOCJson(path, silent=self.silent).json_get_value('all')
 
         if ioc_common.check_truthy(conf['template']):
-            target = f'{self.pool}/iocage/templates/{uuid}@{snapshot}'
+            target = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'templates', f"{uuid}@{snapshot}"
+            )
         else:
-            target = f'{self.pool}/iocage/jails/{uuid}@{snapshot}'
+            target = os.path.join(
+                self.zpool.name, self.zpool.prefix, 'iocage',
+                'jails', f"{uuid}@{snapshot}"
+            )
 
         # Let's verify target exists and then destroy it, else log it
         snapshot = Snapshot(target)

--- a/iocage_lib/zfs.py
+++ b/iocage_lib/zfs.py
@@ -33,7 +33,7 @@ class ZFSException(Exception):
 
 
 IOCAGE_POOL_PROP = 'org.freebsd.ioc:active'
-
+IOCAGE_PREFIX_PROP = 'org.freebsd.ioc:prefix'
 
 def list_pools():
     return list(filter(
@@ -92,7 +92,7 @@ def pool_properties(pool):
 
 def iocage_activated_pool():
     for pool in list_pools():
-        if dataset_properties(pool).get('org.freebsd.ioc:active') == 'yes':
+        if dataset_properties(pool).get(IOCAGE_POOL_PROP) == 'yes':
             return pool
     else:
         return None
@@ -101,8 +101,9 @@ def iocage_activated_pool():
 def iocage_activated_dataset():
     pool = iocage_activated_pool()
     if pool:
-        if os.path.join(pool, 'iocage') in get_dependents(pool, depth=1):
-            return os.path.join(pool, 'iocage')
+        prefix = dataset_properties(pool).get(IOCAGE_PREFIX_PROP, '')
+        if os.path.join(pool, prefix, 'iocage') in get_dependents(pool):
+            return os.path.join(pool, prefix, 'iocage')
 
     return None
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -vvv -rs --ignore=setup.py --pep8 --cov-report term-missing --cov=./iocage_lib --cov=./iocage_cli
+addopts = -vvv --ignore=setup.py --pep8 --cov-report term-missing --cov=./iocage_lib --cov=./iocage_cli
 pep8maxlinelength = 80
 pep8ignore = * ALL
 markers =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,9 @@ def pytest_addoption(parser):
         '--image', action='store_true', default=False,
         help='Run image operations (export/import)'
     )
+    parser.addoption(
+        '--prefix', action='store', default='',
+        help='Prefix to use in ZFS dataset paths')
 
 
 def pytest_runtest_setup(item):
@@ -146,6 +149,12 @@ def pytest_runtest_setup(item):
 def zpool(request):
     """Specify a zpool to use."""
     return request.config.getoption('--zpool')
+
+
+@pytest.fixture
+def prefix(request):
+    """Specify a prefix to use in ZFS dataset paths"""
+    return request.config.getoption('--prefix')
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,12 @@ def jail():
 
 
 @pytest.fixture
+def snapshot():
+    from tests.data_classes import Snapshot
+    return Snapshot
+
+
+@pytest.fixture
 def resource_selector():
     from tests.data_classes import ResourceSelector
     return ResourceSelector()

--- a/tests/data_classes.py
+++ b/tests/data_classes.py
@@ -27,7 +27,7 @@ class Row:
         for attr in [
             'name', 'jid', 'state', 'release', 'ip4', 'ip6', 'orig_release',
             'boot', 'type', 'template', 'basejail', 'crt', 'res', 'qta',
-            'use', 'ava', 'created', 'rsize', 'used', 'orig_name'
+            'use', 'ava', 'created', 'rsize', 'used', 'orig_name', 'jail'
         ]:
             setattr(self, attr, None)
 
@@ -268,6 +268,10 @@ class Row:
         self.name, self.created, self.rsize, self.used = self.standard_parse()
 
 
+    def snapall_parse(self):
+        self.jail, self.name, self.created, self.rsize, self.used = self.standard_parse()
+
+
 class ZFS:
     # TODO: Improve how we manage zfs object here
     pool = None
@@ -361,12 +365,24 @@ class Resource:
     DEFAULT_JSON_FILE = 'config.json'
 
     def __init__(self, name, zfs=None):
-        self.name = name
-        self.zfs = ZFS() if not zfs else zfs
+        super().__setattr__('name', name)
+        super().__setattr__('zfs', ZFS() if not zfs else zfs)
         assert isinstance(self.zfs, ZFS) is True
 
+    def __eq__(self, other):
+        return self.name == other.name
+    
+    def __hash__(self):
+        return hash(self.name)
+    
     def __repr__(self):
         return self.name
+
+    def __setattr__(self, name, attr_value):
+        raise AttributeError(f"Resources are immutable. Cannot set attribute '{name}'.")
+
+    def __delattr__(self, name):
+        raise AttributeError(f"Resources are immutable. Cannot delete attribute '{name}'.")
 
     def convert_to_row(self, **kwargs):
         raise NotImplemented
@@ -376,12 +392,12 @@ class Snapshot(Resource):
 
     def __init__(self, name, parent_dataset, zfs=None):
         super().__init__(name, zfs)
-        self.parent = parent_dataset
+        object.__setattr__(self, 'parent', parent_dataset)
         if isinstance(self.parent, str):
-            self.parent = Jail(self.parent)
+            object.__setattr__(self, 'parent', Jail(self.parent))
         if self.exists:
             for k, v in self.zfs.get_snapshot_safely(self.name).items():
-                setattr(self, k, v)
+                object.__setattr__(self, k, v)
 
     @property
     def exists(self):
@@ -625,7 +641,7 @@ class Jail(Resource):
     @property
     def is_cloned(self):
         return bool(
-            self.jail_dataset[
+            self.root_dataset[
                 'properties'
             ].get('origin', {}).get('value')
         )
@@ -795,3 +811,20 @@ class ResourceSelector:
         return [
             j for j in self.all_jails if j.config.get(key, None) == value
         ]
+
+    @property
+    def cloned_snapshots_set(self):
+        cloned_jails = self.cloned_jails
+        origins = {
+            jail.root_dataset['properties']['origin']['value']
+            for jail in cloned_jails
+        }
+        origins |= {
+            jail.jail_dataset['properties']['origin']['value']
+            for jail in cloned_jails
+        }
+        origins -= { "" }
+        return {
+            Snapshot(origin, origin.rsplit('@', 1)[0])
+            for origin in origins
+        }

--- a/tests/functional_tests/0001_activate_test.py
+++ b/tests/functional_tests/0001_activate_test.py
@@ -31,11 +31,16 @@ require_zpool = pytest.mark.require_zpool
 
 @require_root
 @require_zpool
-def test_activate(zpool, invoke_cli, zfs):
+def test_activate(zpool, prefix, invoke_cli, zfs):
+    args = [zpool]
+    if prefix != '':
+        args.extend(['-p', prefix])
     invoke_cli(
-        ['activate', zpool]
+        ['activate', *args]
     )
 
     zfs.set_pool()
 
     assert zfs.pool == zpool, f'Failed to activate {zpool}'
+    if prefix != '':
+        assert zfs.prefix == prefix, f'Failed to set prefix {prefix}'

--- a/tests/functional_tests/0018_snapshot_test.py
+++ b/tests/functional_tests/0018_snapshot_test.py
@@ -30,6 +30,7 @@ require_zpool = pytest.mark.require_zpool
 
 
 SNAP_NAME = 'snaptest'
+SNAPALL_NAME = 'snapalltest'
 
 
 def common_function(invoke_cli, jails, skip_test):
@@ -44,6 +45,20 @@ def common_function(invoke_cli, jails, skip_test):
     assert [
         s.id.split('@')[1] for s in jail.recursive_snapshots
     ].count(SNAP_NAME) >= 2
+
+
+def all_jails_function(invoke_cli, jails, skip_test):
+    skip_test(not jails)
+
+    invoke_cli(
+        ['snapshot', 'ALL', '-n', SNAPALL_NAME]
+    )
+
+    for jail in jails:
+        # We use count because of template and cloned jails
+        assert [
+            s.id.split('@')[1] for s in jail.recursive_snapshots
+        ].count(SNAPALL_NAME) >= 2
 
 
 @require_root
@@ -66,3 +81,9 @@ def test_02_snapshot_of_template_jail(invoke_cli, resource_selector, skip_test):
 @require_zpool
 def test_03_snapshot_of_cloned_jail(invoke_cli, resource_selector, skip_test):
     common_function(invoke_cli, resource_selector.cloned_jails, skip_test)
+
+
+@require_root
+@require_zpool
+def test_04_snapshot_of_all_jails(invoke_cli, resource_selector, skip_test):
+    all_jails_function(invoke_cli, resource_selector.all_jails, skip_test)

--- a/tests/functional_tests/0019_list_snapshot_test.py
+++ b/tests/functional_tests/0019_list_snapshot_test.py
@@ -37,7 +37,7 @@ def common_function(
     jails_as_rows, full=False
 ):
     for flag in SORTING_FLAGS:
-        if type(jail) is list:
+        if isinstance(jail, list):
             command = ['snaplist', 'ALL', '-s', flag]
         else:
             command = ['snaplist', jail.name, '-s', flag]
@@ -48,7 +48,7 @@ def common_function(
             command
         )
 
-        if type(jail) is list:
+        if isinstance(jail, list):
             jails = jail
             orig_list = parse_rows_output(result.output, 'snapall')
             verify_list = []


### PR DESCRIPTION
Hello,

This PR aimes to close #33 and currently expects #32 being merged first.

I implemented a `--prefix` option to the `activate` command. This prefix is currently saved in a zfs property of the pool, like the active pool flag.
Non-regression tests are passing (see checks on fork repo or directly on Cirrus CI).

The issue that remains is that jails, even if they are exposed a dataset they can use, cannot modify the zfs properties of the host pool. So I am not sure how to proceed from there.

I am thinking of implementing a configuration file / a configuration option in `/etc/rc.conf` - but that would break the current iocage philosophy of working only with zfs as its source of information. We could however limit the damage by leaving it optional and only using that way of working if the file / option exists.

What do you think?

----

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
