### PR TITLE
ioc_start.py: allow 'none' bridge in interfaces

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1151,7 +1151,7 @@ class IOCStart(object):
         """
         Start VNET on interface
 
-        :param nic_defs: comma separated interface definitions (nic, bridge)
+        :param nic_defs: comma separated interface definitions (nic:bridge, nic:bridge...)
         :param net_configs: Tuple of IP address and router pairs
         :param jid: The jails ID
         """
@@ -1167,7 +1167,7 @@ class IOCStart(object):
             try:
                 if self.get(f"{nic}_mtu") != 'auto':
                     membermtu = self.get(f"{nic}_mtu")
-                elif not nat_addr:
+                elif not nat_addr and bridge != 'none':
                     membermtu = self.find_bridge_mtu(bridge)
                 else:
                     membermtu = self.get('vnet_default_mtu')
@@ -1301,7 +1301,7 @@ class IOCStart(object):
                 stderr=su.STDOUT
             )
 
-            if not nat_addr:
+            if bridge != 'none' and not nat_addr:
                 try:
                     # Host interface as supplied by user also needs to be on
                     # the bridge
@@ -1319,7 +1319,7 @@ class IOCStart(object):
                     ['ifconfig', bridge, 'addm', f'{nic}.{jid}', 'up'],
                     stderr=su.STDOUT
                 )
-            else:
+            elif nat_addr:
                 iocage_lib.ioc_common.checkoutput(
                     ['ifconfig', f'{nic}.{jid}', 'inet', f'{nat_addr}/30'],
                     stderr=su.STDOUT

--- a/tests/data_classes.py
+++ b/tests/data_classes.py
@@ -669,10 +669,11 @@ class Jail(Resource):
                 ip for ip in ips if ip not in skip_ips
             ]
 
-    def run_command(self, command):
+    def run_command(self, command, jailed=True):
         # Returns a tuple - stdout, stderr
-        assert self.running is True
-        command = ['jexec', f'ioc-{self.name}'] + command
+        if jailed:
+            assert self.running is True
+            command = ['jexec', f'ioc-{self.name}'] + command
         try:
             stdout, stderr = subprocess.Popen(
                 command, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
Iocage currently expects interfaces to be specified in the nic:bridge format, where bridge cannot be none. This results in iocage always creating a bridge to which VNET jail epair interfaces are added as members.

In a scenario where the user wants jails to be isolated on the data-link layer (OSI layer 2 / Ethernet) and use the host as a router, this bridge is unnecessery. It can also result in illegitimate cross-jail traffic being allowed, since pf filtering on bridge interfaces is disabled by default on FreeBSD systems (net.link.bridge.pfil_bridge=0).

Closes #44

----

Passing CI job: https://cirrus-ci.com/task/6547222509125632

For some reason the CI run using python packages instead of pre-built `pkg` ones is broken (incl. on the master branch) and indefinitely hangs on `tests/functional_tests/0013_import_test.py::test_01_import_jail`, but it is unrelated to this PR.
