### PR TITLE
ioc_start.py: allow setting IP address on lo0

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1174,7 +1174,7 @@ class IOCStart(object):
 
                 dhcp = self.get('dhcp')
 
-                ifaces = []
+                ifaces = ['lo0']
 
                 for addrs, gw, ipv6 in net_configs:
                     if (
@@ -1193,7 +1193,7 @@ class IOCStart(object):
                             # They didn't supply an interface, assuming default
                             iface, ip = "vnet0", addr
 
-                        if iface not in nics:
+                        if iface not in nics and iface != 'lo0':
                             continue
 
                         if iface not in ifaces:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1151,7 +1151,7 @@ class IOCStart(object):
         """
         Start VNET on interface
 
-        :param nic_defs: comma separated interface definitions (nic, bridge)
+        :param nic_defs: comma separated interface definitions (nic:bridge, nic:bridge...)
         :param net_configs: Tuple of IP address and router pairs
         :param jid: The jails ID
         """
@@ -1167,7 +1167,7 @@ class IOCStart(object):
             try:
                 if self.get(f"{nic}_mtu") != 'auto':
                     membermtu = self.get(f"{nic}_mtu")
-                elif not nat_addr:
+                elif not nat_addr and bridge != 'none':
                     membermtu = self.find_bridge_mtu(bridge)
                 else:
                     membermtu = self.get('vnet_default_mtu')
@@ -1301,7 +1301,7 @@ class IOCStart(object):
                 stderr=su.STDOUT
             )
 
-            if not nat_addr:
+            if bridge != 'none' and not nat_addr:
                 try:
                     # Host interface as supplied by user also needs to be on
                     # the bridge
@@ -1319,7 +1319,7 @@ class IOCStart(object):
                     ['ifconfig', bridge, 'addm', f'{nic}.{jid}', 'up'],
                     stderr=su.STDOUT
                 )
-            else:
+            elif nat_addr:
                 iocage_lib.ioc_common.checkoutput(
                     ['ifconfig', f'{nic}.{jid}', 'inet', f'{nat_addr}/30'],
                     stderr=su.STDOUT

--- a/tests/data_classes.py
+++ b/tests/data_classes.py
@@ -669,10 +669,11 @@ class Jail(Resource):
                 ip for ip in ips if ip not in skip_ips
             ]
 
-    def run_command(self, command):
+    def run_command(self, command, jailed=True):
         # Returns a tuple - stdout, stderr
-        assert self.running is True
-        command = ['jexec', f'ioc-{self.name}'] + command
+        if jailed:
+            assert self.running is True
+            command = ['jexec', f'ioc-{self.name}'] + command
         try:
             stdout, stderr = subprocess.Popen(
                 command, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/tests/functional_tests/0004_start_test.py
+++ b/tests/functional_tests/0004_start_test.py
@@ -57,8 +57,9 @@ def test_02_start_rc_jail(invoke_cli, resource_selector):
     for jail in resource_selector.rcjails:
         assert jail.running is True, f'{jail.name} not running'
 
-# TODO: Let's also start jails in a single command to test that out
 
+# Network-related tests belong here because the code is only executed at jail
+# start time.
 @require_root
 @require_zpool
 def test_03_create_and_start_nobridge_vnet_jail(release, jail, invoke_cli):
@@ -109,3 +110,28 @@ def test_03_create_and_start_nobridge_vnet_jail(release, jail, invoke_cli):
 
     finally:
         os.remove(path)
+
+
+@require_root
+@require_zpool
+def test_04_vnet_jail_with_loopback_alias(release, jail, invoke_cli):
+    jail = jail('loopback_alias_jail')
+
+    invoke_cli([
+        'create', '-r', release, '-n', jail.name,
+        'boot=on', 'vnet=on', 'defaultrouter=none',
+        f'ip4_addr=lo0|192.168.2.10'
+    ])
+
+    assert jail.exists is True
+    assert jail.running is True
+
+    stdout, stderr = jail.run_command(['ifconfig', 'lo0'])
+    assert bool(stderr) is False, f'Ifconfig returned an error: {stderr}'
+    assert '192.168.2.10' in stdout, (
+        'Could not set address on loopback interface.'
+    )
+
+    invoke_cli([
+        'destroy', jail.name, '-f'
+    ])


### PR DESCRIPTION
Please merge #47 first.

----

Currently, iocage ignores IP addresses given for the loopback interface
lo0 that exists by default in a VNET jail. Adding addresses to that
interface can be useful, for instance to implement rfc7404 addressing
where link-local addresses are used for interconnections, and routable
addresses are set on loopback interfaces.

This commit enables setting additional addresses on the lo0 interface
using the usual ip4_addr or ip6_addr settings.
For instance: ip4_addr='lo0|192.168.2.10'

Closes https://github.com/freebsd/iocage/issues/46