### PR TITLE
Add hardening measures on untar

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -47,6 +47,9 @@ import iocage_lib.ioc_start
 from iocage_lib.pools import Pool
 from iocage_lib.dataset import Dataset
 
+# deliberately crash if tarfile doesn't have required filter
+tarfile.tar_filter
+
 
 class IOCFetch:
 
@@ -817,7 +820,7 @@ class IOCFetch:
             # removing them first.
             member = self.__fetch_extract_remove__(f)
             member = self.__fetch_check_members__(member)
-            f.extractall(dest, members=member)
+            f.extractall(dest, members=member, filter='tar')
 
     def fetch_update(self, cli=False, uuid=None):
         """This calls 'freebsd-update' to update the fetched RELEASE."""

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -61,6 +61,9 @@ from iocage_lib.dataset import Dataset
 GIT_LOCK = threading.Lock()
 RE_PLUGIN_VERSION = re.compile(r'"path":"([/\.\+,\d\w-]*)\.txz"')
 
+# deliberately crash if tarfile doesn't have required filter
+tarfile.tar_filter
+
 
 class IOCPlugin(object):
 
@@ -157,7 +160,7 @@ class IOCPlugin(object):
                             shutil.copyfileobj(r.raw, f)
 
                     with tarfile.open(packagesite_txz_path) as p_file:
-                        p_file.extractall(path=tmpdir)
+                        p_file.extractall(path=tmpdir, filter='data')
 
                     packagesite_path = os.path.join(tmpdir, 'packagesite.yaml')
                     if not os.path.exists(packagesite_path):


### PR DESCRIPTION
This adds hardening measures while untaring archives fetched over the network (including FreeBSD tarballs and iocage plugins), as implemented by TrueNAS, see:
https://github.com/truenas/iocage/pull/358

This reduces the impact of intentionally malicious or accidentally broken archives.

Please note that users are still advised to only fetch from trusted sources and make use of TLS to prevent MITM attacks.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
