### PR TITLE
Fix hardening measure in release extraction

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -47,9 +47,29 @@ import iocage_lib.ioc_start
 from iocage_lib.pools import Pool
 from iocage_lib.dataset import Dataset
 
-# deliberately crash if tarfile doesn't have required filter
-tarfile.tar_filter
-
+# taken from tarfile.tar_filter (and _get_filtered_attrs)
+# basically the same, but **without**:
+# - Clear high mode bits (setuid, setgid, sticky) and
+#   group/other write bits (S_IWGRP | S_IWOTH).
+def untar_release_filter(member, dest_path):
+    new_attrs = {}
+    name = member.name
+    dest_path = os.path.realpath(dest_path)
+    # Strip leading / (tar's directory separator) from filenames.
+    # Include os.sep (target OS directory separator) as well.
+    if name.startswith(('/', os.sep)):
+        name = new_attrs['name'] = member.path.lstrip('/' + os.sep)
+    if os.path.isabs(name):
+        # Path is absolute even after stripping.
+        # For example, 'C:/foo' on Windows.
+        raise tarfile.AbsolutePathError(member)
+    # Ensure we stay in the destination
+    target_path = os.path.realpath(os.path.join(dest_path, name))
+    if os.path.commonpath([target_path, dest_path]) != dest_path:
+        raise tarfile.OutsideDestinationError(member, target_path)
+    if new_attrs:
+        return member.replace(**new_attrs, deep=False)
+    return member
 
 class IOCFetch:
 
@@ -820,7 +840,7 @@ class IOCFetch:
             # removing them first.
             member = self.__fetch_extract_remove__(f)
             member = self.__fetch_check_members__(member)
-            f.extractall(dest, members=member, filter='tar')
+            f.extractall(dest, members=member, filter=untar_release_filter)
 
     def fetch_update(self, cli=False, uuid=None):
         """This calls 'freebsd-update' to update the fetched RELEASE."""


### PR DESCRIPTION
In freebsd/iocage#49 a hardening measure was imported from truenas/iocage#358. This hardening measure limits what can be extracted (location and attributes). It is implemented by applying the 'tar' filter from tarfile. That filter does this[0]:

- Strip leading slashes (/ and os.sep) from filenames.
- Refuse to extract files with absolute paths (in case the name is absolute even after stripping slashes, e.g. C:/foo on Windows). This raises AbsolutePathError.
- Refuse to extract files whose absolute path (after following symlinks) would end up outside the destination. This raises OutsideDestinationError.
- Clear high mode bits (setuid, setgid, sticky) and group/other write bits (S_IWGRP | S_IWOTH).

While the first three modifications are desirable, the last one damages the extracted release image, as things like sticky bits and world writable files are required by a proper FreeBSD (jail) installation.

Fixes freebsd/iocage#54

[0]https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
