### PR TITLE
Update setup.py, new man page location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ from setuptools import find_packages, setup
 
 if os.path.isdir("/".join([sys.prefix, "etc/init.d"])):
     _data = [('etc/init.d', ['rc.d/iocage']),
-             ('man/man8', ['iocage.8.gz'])]
+             ('share/man/man8', ['iocage.8.gz'])]
 else:
     _data = [('etc/rc.d', ['rc.d/iocage']),
-             ('man/man8', ['iocage.8.gz'])]
+             ('share/man/man8', ['iocage.8.gz'])]
 
 if os.path.isdir("/".join([sys.prefix, "share/zsh/site-functions/"])):
     _data.append(('share/zsh/site-functions', ['zsh-completion/_iocage']))


### PR DESCRIPTION
FreeBSD changed the location of man pages.
The current port has a patch to do this change.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
