### PR TITLE
Change 'vnet_default_interface' to match new reality

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1149,7 +1149,7 @@ class IOCConfiguration:
             'vnet1_mac': 'none',
             'vnet2_mac': 'none',
             'vnet3_mac': 'none',
-            'vnet_default_interface': 'auto',
+            'vnet_default_interface': 'none',
             'devfs_ruleset': str(iocage_lib.ioc_common.IOCAGE_DEVFS_RULESET),
             'exec_start': '/bin/sh /etc/rc',
             'exec_stop': '/bin/sh /etc/rc.shutdown',


### PR DESCRIPTION
Otherwise, the uplink interface will be added to the bridge after updating iocage, which is functionally- as well as security-wise quite some headache.

Fixes #70

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
