### PR TITLE
correct jail name matching

### DIFF
--- a/iocage_lib/cache.py
+++ b/iocage_lib/cache.py
@@ -88,7 +88,7 @@ class Cache:
                 for ds in get_all_dependents():
                     self.dataset_dep_data[ds] = []
                     for k in self.dataset_dep_data:
-                        if ds.startswith(k):
+                        if ds.startswith(k+"/") or ds == k:
                             self.dataset_dep_data[k].append(ds)
 
             return get_dependents_with_depth(


### PR DESCRIPTION
used to destroy all jails with names starting like the one you destroy

now matching only name or name/*, not name*

fix #62