### PR TITLE
remove vnet from vnet_interfaces on stop

### DIFF
--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -239,6 +239,18 @@ class IOCStop(object):
         destroy_nic = True if dhcp or ip4_addr != 'none' or \
             ip6_addr != 'none' or (nat and vnet) else False
 
+        # disconnect vnet_interfaces from jail before stoppping
+        if vnet and self.conf["vnet_interfaces"] != 'none':
+            vnet_err = []
+
+            for nic in self.conf["vnet_interfaces"].split(","):
+                try:
+                    iocage_lib.ioc_common.checkoutput(
+                        ["ifconfig",f"{nic}", "-vnet", f"ioc-{self.uuid}"],
+                        stderr=su.STDOUT)
+                except su.CalledProcessError as err:
+                    vnet_err.append(err.output.decode().rstrip())
+
         if vnet and destroy_nic:
             vnet_err = []
 


### PR DESCRIPTION
on stop, if ifconfig -vnet was not used to release all ${vnet_interfaces} from jail before destroying jail.
This made the interface unuseable for another ~15mn timeout.

fix #59
