### PR TITLE
add JID and JNAME vars for poststart script

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -873,7 +873,7 @@ class IOCStart(object):
         # Running exec_poststart now
         poststart_success, poststart_error = \
             iocage_lib.ioc_common.runscript(
-                exec_poststart
+                f"export JID=ioc-{self.uuid} JNAME={self.uuid};"+exec_poststart
             )
 
         if poststart_error:


### PR DESCRIPTION
could fix #66 the lazy way

just adding JID and JNAME vars available for exec_poststart