### PR TITLE
Cleaner fix for poststart environment variables

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -871,9 +871,15 @@ class IOCStart(object):
                 f.write(f'{success}\n{error}')
 
         # Running exec_poststart now
+        _, jid = iocage_lib.ioc_list.IOCList().list_get_jid(self.uuid)
+        post_start_env = {
+            **os.environ,
+            'JID': jid,
+            'JNAME': f"ioc-{self.uuid}",
+        }
         poststart_success, poststart_error = \
             iocage_lib.ioc_common.runscript(
-                exec_poststart
+                exec_poststart, post_start_env
             )
 
         if poststart_error:


### PR DESCRIPTION
I propose this cleaner fix to add JID and JNAME environment variables to the `exec_poststart` command. (As discussed in #66 )

It avoids touching the command itself and sets values that match standard tools output such as `jls`.