### PR TITLE
ioc_start.py: Stop passing allow.dying argument

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -590,7 +590,6 @@ class IOCStart(object):
                 f'exec.timeout={exec_timeout}',
                 f'stop.timeout={stop_timeout}',
                 f'mount.fstab={self.path}/fstab',
-                'allow.dying',
                 f'exec.consolelog={self.iocroot}/log/ioc-'
                 f'{self.uuid}-console.log',
                 f'ip_hostname={ip_hostname}' if ip_hostname else '',


### PR DESCRIPTION
This was causing "iocage stop foo" to print a warning, which is then gets interpreted as error by iocage:

>   + Removing devfs_ruleset: 1000 OK
>   + Removing jail process FAILED:
> jail: the 'allow.dying' parameter and '-d' flag are deprecated and have no effect.

The jail man pages says about this argument:

> This is deprecated and has no effect.