### PR TITLE
CI: Remove Python 3.9 workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9,3.11]
+        python-version: [3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.9 is long deprecated and isn't used in FreeBSD Ports for a while.