### PR TITLE
Rework use of proxy environment variables

### DIFF
--- a/iocage_cli/exec.py
+++ b/iocage_cli/exec.py
@@ -40,7 +40,10 @@ __rootcmd__ = True
 @click.argument("command", nargs=-1, type=click.UNPROCESSED)
 @click.option('--force', '-f', default=False, is_flag=True,
               help='Start the jail if it\'s not running.')
-def cli(command, jail, host_user, jail_user, force):
+@click.option('--keep_proxy', '-p', default=False, is_flag=True,
+              help='Keep the host\'s proxy environment variables (http_proxy, '
+                   'HTTPS_PROXY, HTTP_PROXY_AUTH, NO_PROXY)')
+def cli(command, jail, host_user, jail_user, force, keep_proxy):
     """Runs the command given inside the specified jail as the supplied
     user."""
     # We may be getting ';', '&&' and so forth. Adding the shell for safety.
@@ -66,6 +69,7 @@ def cli(command, jail, host_user, jail_user, force):
             host_user,
             jail_user,
             interactive=True,
+            keep_proxy=keep_proxy,
             start_jail=force
         )
     except KeyboardInterrupt:

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -52,6 +52,7 @@ class IOCExec(object):
         skip=False,
         stdin_bytestring=None,
         su_env=None,
+        keep_proxy=False,
         decode=False,
         callback=None
     ):
@@ -77,14 +78,17 @@ class IOCExec(object):
         su_env.setdefault('TERM', 'xterm-256color')
         su_env.setdefault('LANG', env_lang)
         su_env.setdefault('LC_ALL', env_lang)
-        if os.environ.get('http_proxy', '') != '':
-            su_env.setdefault('http_proxy', os.environ.get('http_proxy', ''))
-        elif os.environ.get('HTTP_PROXY', '') != '':
-            su_env.setdefault('HTTP_PROXY', os.environ.get('HTTP_PROXY', ''))
-        if os.environ.get('HTTP_PROXY_AUTH', '') != '':
-            su_env.setdefault('HTTP_PROXY_AUTH', os.environ.get('HTTP_PROXY_AUTH', ''))
-        if os.environ.get('NO_PROXY', '') != '':
-            su_env.setdefault('NO_PROXY', os.environ.get('NO_PROXY', ''))
+        if unjailed or keep_proxy:
+            if os.environ.get('http_proxy', '') != '':
+                su_env.setdefault('http_proxy', os.environ.get('http_proxy', ''))
+            elif os.environ.get('HTTP_PROXY', '') != '':
+                su_env.setdefault('HTTP_PROXY', os.environ.get('HTTP_PROXY', ''))
+            if os.environ.get('HTTPS_PROXY', '') != '':
+                su_env.setdefault('HTTPS_PROXY', os.environ.get('HTTPS_PROXY', ''))
+            if os.environ.get('HTTP_PROXY_AUTH', '') != '':
+                su_env.setdefault('HTTP_PROXY_AUTH', os.environ.get('HTTP_PROXY_AUTH', ''))
+            if os.environ.get('NO_PROXY', '') != '':
+                su_env.setdefault('NO_PROXY', os.environ.get('NO_PROXY', ''))
 
         self.su_env = su_env
         self.callback = callback

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -77,7 +77,9 @@ class IOCExec(object):
         su_env.setdefault('TERM', 'xterm-256color')
         su_env.setdefault('LANG', env_lang)
         su_env.setdefault('LC_ALL', env_lang)
-        if os.environ.get('HTTP_PROXY', '') != '':
+        if os.environ.get('http_proxy', '') != '':
+            su_env.setdefault('http_proxy', os.environ.get('http_proxy', ''))
+        elif os.environ.get('HTTP_PROXY', '') != '':
             su_env.setdefault('HTTP_PROXY', os.environ.get('HTTP_PROXY', ''))
         if os.environ.get('HTTP_PROXY_AUTH', '') != '':
             su_env.setdefault('HTTP_PROXY_AUTH', os.environ.get('HTTP_PROXY_AUTH', ''))

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -79,7 +79,11 @@ class IOCUpgrade:
             'HOME': '/',
             'TERM': 'xterm-256color'
         }
-        for envvar in ['HTTP_PROXY', 'HTTPS_PROXY', 'HTTP_PROXY_AUTH', 'NO_PROXY']:
+        if os.environ.get('http_proxy', '') != '':
+            http_proxy_var = 'http_proxy'
+        else:
+            http_proxy_var = 'HTTP_PROXY'
+        for envvar in [http_proxy_var, 'HTTPS_PROXY', 'HTTP_PROXY_AUTH', 'NO_PROXY']:
             if os.environ.get(envvar, '') != '':
                 self.upgrade_env[envvar] = os.environ.get(envvar)
 

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -791,7 +791,8 @@ class IOCage:
 
     def exec_all(
         self, command, host_user='root', jail_user=None, console=False,
-        start_jail=False, interactive=False, unjailed=False, msg_return=False
+        start_jail=False, interactive=False, unjailed=False, msg_return=False,
+        keep_proxy=False
     ):
         """Runs exec for all jails"""
         self._all = False
@@ -799,18 +800,19 @@ class IOCage:
             self.jail = jail
             self.exec(
                 command, host_user, jail_user, console, start_jail,
-                interactive, unjailed, msg_return
+                interactive, unjailed, msg_return, keep_proxy
             )
 
     def exec(
         self, command, host_user='root', jail_user=None, console=False,
-        start_jail=False, interactive=False, unjailed=False, msg_return=False
+        start_jail=False, interactive=False, unjailed=False, msg_return=False,
+        keep_proxy=False
     ):
         """Executes a command in the jail as the supplied users."""
         if self._all:
             self.exec_all(
                 command, host_user, jail_user, console, start_jail,
-                interactive, unjailed, msg_return
+                interactive, unjailed, msg_return, keep_proxy
             )
             return
 
@@ -918,6 +920,7 @@ class IOCage:
                 host_user=host_user,
                 jail_user=jail_user,
                 unjailed=pkg,
+                keep_proxy=keep_proxy,
                 skip=True
             )
             return
@@ -930,6 +933,7 @@ class IOCage:
                 host_user=host_user,
                 jail_user=jail_user,
                 unjailed=unjailed,
+                keep_proxy=keep_proxy,
                 su_env=su_env
             ) as _exec:
                 output = ioc_common.consume_and_log(


### PR DESCRIPTION
To address #86, by default, we do not pass proxy environment variables anymore, but we add a command-line flag (and API argument) to enable this behaviour for people who prefer it that way.

The `http_proxy` variable is taken into account and has priority over `HTTP_PROXY` if both are set as proposed in #84.