### PR TITLE
use jail's fib for gateway detection

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1094,14 +1094,14 @@ def parse_package_name(pkg):
     }
 
 
-def get_host_gateways():
+def get_host_gateways(fib=0):
     gateways = {'ipv4': {'gateway': None, 'interface': None},
                 'ipv6': {'gateway': None, 'interface': None}}
     af_mapping = {
         'Internet': 'ipv4',
         'Internet6': 'ipv6'
     }
-    output = checkoutput(['netstat', '-r', '-n', '--libxo', 'json'])
+    output = checkoutput(['setfib', f'{fib}', 'netstat', '-r', '-n', '--libxo', 'json'])
     route_families = (json.loads(output)
                       ['statistics']
                       ['route-information']

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -180,7 +180,7 @@ class IOCStart(object):
         localhost_ip = self.conf['localhost_ip']
         self.defaultrouter = self.conf['defaultrouter']
         self.defaultrouter6 = self.conf['defaultrouter6']
-        self.host_gateways = iocage_lib.ioc_common.get_host_gateways()
+        self.host_gateways = iocage_lib.ioc_common.get_host_gateways(self.exec_fib)
 
         fstab_list = []
         with open(


### PR DESCRIPTION
make iocage use jail's "exec_fib" to detect correct gateway instead of using default host's (fib 0) 
fix #104