### PR TITLE
Configure IPv6 correctly when IPv4 DHCP is enabled

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1182,7 +1182,7 @@ class IOCStart(object):
                 ifaces = ['lo0']
 
                 for addrs, gw, ipv6 in net_configs:
-                    if (
+                    if not ipv6 and (
                         dhcp or 'DHCP' in self.ip4_addr.upper()
                     ) and 'accept_rtadv' not in addrs:
                         # Spoofing IP address, it doesn't matter with DHCP
@@ -1358,7 +1358,7 @@ class IOCStart(object):
             ifconfig = [iface, ip, 'alias']
 
         try:
-            if not wants_dhcp and ip != 'accept_rtadv':
+            if (ipv6 or not wants_dhcp) and ip != 'accept_rtadv':
                 # Jail side
                 iocage_lib.ioc_common.checkoutput(
                     ['setfib', self.exec_fib, 'jexec', f'ioc-{self.uuid}',

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -190,3 +190,200 @@ member_if_config = (
     "        media: Ethernet autoselect (1000baseT <full-duplex>)\n"
     "        status: active\n"
     )
+
+
+# ─── Tests for start_network_vnet_addr ───────────────────────────────────────
+#
+# Regression tests for the fix where IPv4 DHCP settings incorrectly
+# prevented static IPv6 addresses from being assigned.
+
+def _make_iocstart_for_addr(**overrides):
+    """Create an IOCStart instance with properties needed for addr tests."""
+    iocstart = ioc_start.IOCStart("test-jail", "", unit_test=True)
+    iocstart.exec_fib = '0'
+    iocstart.ip4_addr = overrides.get('ip4_addr', 'none')
+
+    dhcp_val = overrides.get('dhcp', 0)
+    iocstart.get = lambda prop: dhcp_val if prop == 'dhcp' else 'auto'
+
+    return iocstart
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_ipv6_static_applied_when_dhcp_enabled(mock_checkoutput):
+    """Static IPv6 must be assigned even when IPv4 DHCP is enabled."""
+    iocstart = _make_iocstart_for_addr(dhcp=1)
+    iocstart.start_network_vnet_addr(
+        'vnet0', '2001:db8::1/64', 'fe80::1', ipv6=True
+    )
+    mock_checkoutput.assert_called_once()
+    args = mock_checkoutput.call_args[0][0]
+    assert 'inet6' in args
+    assert '2001:db8::1/64' in args
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_ipv4_skipped_when_dhcp_enabled(mock_checkoutput):
+    """IPv4 ifconfig should be skipped when DHCP is handling it."""
+    iocstart = _make_iocstart_for_addr(dhcp=1)
+    iocstart.start_network_vnet_addr(
+        'vnet0', '192.168.1.10/24', '192.168.1.1', ipv6=False
+    )
+    mock_checkoutput.assert_not_called()
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_ipv4_applied_when_dhcp_disabled(mock_checkoutput):
+    """IPv4 static must be assigned when DHCP is off."""
+    iocstart = _make_iocstart_for_addr(dhcp=0)
+    iocstart.start_network_vnet_addr(
+        'vnet0', '192.168.1.10/24', '192.168.1.1', ipv6=False
+    )
+    mock_checkoutput.assert_called_once()
+    args = mock_checkoutput.call_args[0][0]
+    assert '192.168.1.10/24' in args
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_ipv6_applied_when_dhcp_disabled(mock_checkoutput):
+    """IPv6 static must be assigned when DHCP is off."""
+    iocstart = _make_iocstart_for_addr(dhcp=0)
+    iocstart.start_network_vnet_addr(
+        'vnet0', '2001:db8::1/64', 'fe80::1', ipv6=True
+    )
+    mock_checkoutput.assert_called_once()
+    args = mock_checkoutput.call_args[0][0]
+    assert 'inet6' in args
+    assert '2001:db8::1/64' in args
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_accept_rtadv_never_calls_ifconfig(mock_checkoutput):
+    """accept_rtadv addresses should never invoke ifconfig."""
+    iocstart = _make_iocstart_for_addr(dhcp=0)
+    iocstart.start_network_vnet_addr(
+        'vnet0', 'accept_rtadv', 'fe80::1', ipv6=True
+    )
+    mock_checkoutput.assert_not_called()
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_dhcp_in_ip4_addr_string_skips_ipv4(mock_checkoutput):
+    """ip4_addr containing DHCP should also suppress IPv4 ifconfig."""
+    iocstart = _make_iocstart_for_addr(dhcp=0, ip4_addr='vnet0|DHCP')
+    iocstart.start_network_vnet_addr(
+        'vnet0', '192.168.1.10/24', '192.168.1.1', ipv6=False
+    )
+    mock_checkoutput.assert_not_called()
+
+
+@mock.patch('iocage_lib.ioc_common.checkoutput')
+def test_vnet_addr_dhcp_in_ip4_addr_string_still_applies_ipv6(mock_checkoutput):
+    """ip4_addr containing DHCP must not prevent IPv6 assignment."""
+    iocstart = _make_iocstart_for_addr(dhcp=0, ip4_addr='vnet0|DHCP')
+    iocstart.start_network_vnet_addr(
+        'vnet0', '2001:db8::1/64', 'fe80::1', ipv6=True
+    )
+    mock_checkoutput.assert_called_once()
+    args = mock_checkoutput.call_args[0][0]
+    assert 'inet6' in args
+
+
+# ─── Tests for start_network_interface_vnet address spoofing ─────────────────
+#
+# Regression tests ensuring IPv4 DHCP address spoofing does not affect
+# IPv6 static address entries in net_configs.
+
+def _make_iocstart_for_iface(**overrides):
+    """Create an IOCStart instance with properties needed for iface tests."""
+    iocstart = ioc_start.IOCStart("test-jail", "", unit_test=True)
+    iocstart.exec_fib = '0'
+    iocstart.ip4_addr = overrides.get('ip4_addr', 'vnet0|192.168.1.9')
+    iocstart.ip6_addr = overrides.get(
+        'ip6_addr', 'vnet0|2001:db8::1/64')
+
+    dhcp_val = overrides.get('dhcp', 0)
+    mtu_val = overrides.get('mtu', '1500')
+
+    def mock_get(prop):
+        if prop == 'dhcp':
+            return dhcp_val
+        if prop.endswith('_mtu'):
+            return mtu_val
+        return 'auto'
+
+    iocstart.get = mock_get
+    return iocstart
+
+
+@mock.patch.object(ioc_start.IOCStart, 'start_network_vnet_addr',
+                   return_value=None)
+@mock.patch.object(ioc_start.IOCStart, 'start_network_vnet_iface',
+                   return_value=None)
+def test_iface_vnet_dhcp_does_not_spoof_ipv6_address(
+    mock_iface, mock_addr
+):
+    """When dhcp=1, IPv6 static address must pass through unspoofed."""
+    iocstart = _make_iocstart_for_iface(dhcp=1)
+    net_configs = (
+        (iocstart.ip4_addr, '192.168.1.1', False),
+        (iocstart.ip6_addr, 'fe80::1', True),
+    )
+    iocstart.start_network_interface_vnet('vnet0:bridge0', net_configs, '42')
+
+    # Collect the (ip, ipv6) pairs from all calls to start_network_vnet_addr
+    addr_calls = [(c[0][1], c[0][3]) for c in mock_addr.call_args_list]
+
+    # The IPv6 address must arrive intact (not spoofed to empty)
+    ipv6_calls = [(ip, v6) for ip, v6 in addr_calls if v6]
+    assert len(ipv6_calls) == 1
+    assert ipv6_calls[0][0] == '2001:db8::1/64'
+
+
+@mock.patch.object(ioc_start.IOCStart, 'start_network_vnet_addr',
+                   return_value=None)
+@mock.patch.object(ioc_start.IOCStart, 'start_network_vnet_iface',
+                   return_value=None)
+def test_iface_vnet_dhcp_does_spoof_ipv4_address(
+    mock_iface, mock_addr
+):
+    """When dhcp=1, IPv4 address should be spoofed (DHCP will provide it)."""
+    iocstart = _make_iocstart_for_iface(dhcp=1)
+    net_configs = (
+        (iocstart.ip4_addr, '192.168.1.1', False),
+        (iocstart.ip6_addr, 'fe80::1', True),
+    )
+    iocstart.start_network_interface_vnet('vnet0:bridge0', net_configs, '42')
+
+    addr_calls = [(c[0][1], c[0][3]) for c in mock_addr.call_args_list]
+
+    # The IPv4 address should have been spoofed to empty
+    ipv4_calls = [(ip, v6) for ip, v6 in addr_calls if not v6]
+    assert len(ipv4_calls) == 1
+    assert ipv4_calls[0][0] == "''"
+
+
+@mock.patch.object(ioc_start.IOCStart, 'start_network_vnet_addr',
+                   return_value=None)
+@mock.patch.object(ioc_start.IOCStart, 'start_network_vnet_iface',
+                   return_value=None)
+def test_iface_vnet_no_dhcp_preserves_both_addresses(
+    mock_iface, mock_addr
+):
+    """When dhcp=0, both IPv4 and IPv6 addresses pass through intact."""
+    iocstart = _make_iocstart_for_iface(dhcp=0)
+    net_configs = (
+        (iocstart.ip4_addr, '192.168.1.1', False),
+        (iocstart.ip6_addr, 'fe80::1', True),
+    )
+    iocstart.start_network_interface_vnet('vnet0:bridge0', net_configs, '42')
+
+    addr_calls = [(c[0][1], c[0][3]) for c in mock_addr.call_args_list]
+
+    ipv4_calls = [(ip, v6) for ip, v6 in addr_calls if not v6]
+    ipv6_calls = [(ip, v6) for ip, v6 in addr_calls if v6]
+
+    assert len(ipv4_calls) == 1
+    assert ipv4_calls[0][0] == '192.168.1.9'
+    assert len(ipv6_calls) == 1
+    assert ipv6_calls[0][0] == '2001:db8::1/64'


### PR DESCRIPTION
This PR fixes a long-standing problem with the networking setup.  If IPv4 DHCP was enabled, then the IPv6 network address would be blanked out, resulting in a missing IPv6 address even though it was in the jail configuration.  I commonly use this setup so I can have working IPv4 but a static IPv6 for external connections for the actual hosted services.

Example configuration:

```
    "dhcp": 1,
    "interfaces": "vnet0:bridge0",
    "ip4": "new",
    "ip4_saddrsel": 0,
    "ip6": "new",
    "ip6_addr": "vnet0|2001:8b0:860:4669:47e:93ff:fe80:e610/64",
    "ip6_saddrsel": 0,
    "rtsold": 0,
    "vnet": 1,
```

Current behaviour:

```
ELF ldconfig path: /lib /usr/lib /usr/lib/compat /usr/local/lib /usr/local/lib/compat/pkg /usr/local/lib/compat /usr/local/lib/compat/pkg /
usr/local/lib/gcc14 /usr/local/lib/perl5/5.42/mach/CORE /usr/local/lib/qt6
32-bit compatibility ldconfig path: /usr/lib32 /usr/local/lib32/compat /usr/local/lib32/gcc14
Starting dhclient.
Starting dhclient.
Starting dhclient.
Starting dhclient.
Starting Network: lo0 epair0b.
lo0: flags=1008049<UP,LOOPBACK,RUNNING,MULTICAST,LOWER_UP> metric 0 mtu 16384
        options=680003<RXCSUM,TXCSUM,LINKSTATE,RXCSUM_IPV6,TXCSUM_IPV6>
        inet 127.0.0.1 netmask 0xff000000
        inet6 ::1 prefixlen 128
        inet6 fe80::1%lo0 prefixlen 64 scopeid 0xd
        groups: lo
        nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
epair0b: flags=1008843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,LOWER_UP> metric 0 mtu 1500
        options=200009<RXCSUM,VLAN_MTU,RXCSUM_IPV6>
        ether 06:7e:93:80:e6:10
        hwaddr 58:9c:fc:10:59:08
        inet 192.168.1.74 netmask 0xffffff00 broadcast 192.168.1.255
        inet6 fe80::47e:93ff:fe80:e610%epair0b prefixlen 64 scopeid 0xf
        groups: epair
        media: Ethernet 10Gbase-T (10Gbase-T <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
epair0b: flags=1008843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,LOWER_UP> metric 0 mtu 1500
        options=200009<RXCSUM,VLAN_MTU,RXCSUM_IPV6>
        ether 06:7e:93:80:e6:10
        hwaddr 58:9c:fc:10:59:08
        inet 192.168.1.74 netmask 0xffffff00 broadcast 192.168.1.255
        inet6 fe80::47e:93ff:fe80:e610%epair0b prefixlen 64 scopeid 0xf
        groups: epair
        media: Ethernet 10Gbase-T (10Gbase-T <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
add host 127.0.0.1: gateway lo0 fib 0: route already in table
add host 127.0.0.1: gateway lo0 fib 0: route already in table
add host 127.0.0.1: gateway lo0 fib 0: route already in table
add host ::1: gateway lo0 fib 0: route already in table
add net fe80::: gateway ::1
add net ff02::: gateway ::1
add net ::ffff:0.0.0.0: gateway ::1
add net ::0.0.0.0: gateway ::1
Clearing /tmp (X related).
Updating /var/run/os-release done.
Creating and/or trimming log files.
Updating motd:.
Starting syslogd.
Performing sanity check on sshd configuration.
Starting sshd.
Starting cron.

Sun Mar 22 17:49:35 UTC 2026
```

With the fix:

```
ELF ldconfig path: /lib /usr/lib /usr/lib/compat /usr/local/lib /usr/local/lib/compat/pkg /usr/local/lib/compat /usr/local/lib/compat/pkg /usr/local/lib/gcc14 /usr/local/lib/perl5/5.42/mach/CORE /usr/local/lib/qt6
32-bit compatibility ldconfig path: /usr/lib32 /usr/local/lib32/compat /usr/local/lib32/gcc14
Starting dhclient.
Starting dhclient.
Starting dhclient.
Starting dhclient.
Starting Network: lo0 epair0b.
lo0: flags=1008049<UP,LOOPBACK,RUNNING,MULTICAST,LOWER_UP> metric 0 mtu 16384
        options=680003<RXCSUM,TXCSUM,LINKSTATE,RXCSUM_IPV6,TXCSUM_IPV6>
        inet 127.0.0.1 netmask 0xff000000
        inet6 ::1 prefixlen 128
        inet6 fe80::1%lo0 prefixlen 64 scopeid 0xd
        groups: lo
        nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
epair0b: flags=1008843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,LOWER_UP> metric 0 mtu 1500
        options=200009<RXCSUM,VLAN_MTU,RXCSUM_IPV6>
        ether 06:7e:93:80:e6:10
        hwaddr 58:9c:fc:10:59:08
        inet 192.168.1.74 netmask 0xffffff00 broadcast 192.168.1.255
        inet6 2001:8b0:860:4669:47e:93ff:fe80:e610 prefixlen 64
        inet6 fe80::47e:93ff:fe80:e610%epair0b prefixlen 64 scopeid 0xf
        groups: epair
        media: Ethernet 10Gbase-T (10Gbase-T <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
epair0b: flags=1008843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,LOWER_UP> metric 0 mtu 1500
        options=200009<RXCSUM,VLAN_MTU,RXCSUM_IPV6>
        ether 06:7e:93:80:e6:10
        hwaddr 58:9c:fc:10:59:08
        inet 192.168.1.74 netmask 0xffffff00 broadcast 192.168.1.255
        inet6 2001:8b0:860:4669:47e:93ff:fe80:e610 prefixlen 64
        inet6 fe80::47e:93ff:fe80:e610%epair0b prefixlen 64 scopeid 0xf
        groups: epair
        media: Ethernet 10Gbase-T (10Gbase-T <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
epair0b: flags=1008843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,LOWER_UP> metric 0 mtu 1500
        options=200009<RXCSUM,VLAN_MTU,RXCSUM_IPV6>
        ether 06:7e:93:80:e6:10
        hwaddr 58:9c:fc:10:59:08
        inet 192.168.1.74 netmask 0xffffff00 broadcast 192.168.1.255
        inet6 2001:8b0:860:4669:47e:93ff:fe80:e610 prefixlen 64
        inet6 fe80::47e:93ff:fe80:e610%epair0b prefixlen 64 scopeid 0xf
        groups: epair
        media: Ethernet 10Gbase-T (10Gbase-T <full-duplex>)
        status: active
        nd6 options=23<PERFORMNUD,ACCEPT_RTADV,AUTO_LINKLOCAL>
add host 127.0.0.1: gateway lo0 fib 0: route already in table
add host 127.0.0.1: gateway lo0 fib 0: route already in table
add host 127.0.0.1: gateway lo0 fib 0: route already in table
add host ::1: gateway lo0 fib 0: route already in table
add net fe80::: gateway ::1
add net ff02::: gateway ::1
add net ::ffff:0.0.0.0: gateway ::1
add net ::0.0.0.0: gateway ::1
Clearing /tmp (X related).
Updating /var/run/os-release done.
Creating and/or trimming log files.
Updating motd:.
Starting syslogd.
Performing sanity check on sshd configuration.
Starting sshd.
Starting cron.

Sun Mar 22 18:00:52 UTC 2026
```

You can see with the fix that the IPv6 address is now correctly configured within the jail.

Full disclosure: I used Claude to investigate the codebase in detail to identify the specific cause of the problem and to develop the solution, plus to write the unit tests to prevent the a regression in the future.

This was tested on FreeBSD-15.0-RELEASE-p2.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
