### PR TITLE
Use pkg for dependencies instead of pip in developer workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,25 @@
 ZPOOL=""
 SERVER=""
 PYTHON?=/usr/local/bin/python3
+PYVER!= ${PYTHON} -c "import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))"
 
 depends:
 	@(pkg -vv | grep -e "url.*/latest") > /dev/null 2>&1 || (echo "It is advised pkg url is using \"latest\" instead of \"quarterly\" in /etc/pkg/FreeBSD.conf.";)
 	@test -s ${PYTHON} || (echo "Python binary ${PYTHON} not found, iocage will install python3"; pkg install -q -y python3)
-	${PYTHON} -m ensurepip
-	${PYTHON} -m pip install -Ur requirements.txt
+	pkg install -y \
+		py${PYVER}-click \
+		py${PYVER}-texttable \
+		py${PYVER}-requests \
+		py${PYVER}-coloredlogs \
+		py${PYVER}-netifaces \
+		py${PYVER}-gitpython \
+		py${PYVER}-dnspython \
+		py${PYVER}-jsonschema \
+		py${PYVER}-fastentrypoints \
+		py${PYVER}-pytest
 
 install: depends
-	${PYTHON} setup.py install 
+	${PYTHON} setup.py install
 uninstall:
 	${PYTHON} -m pip uninstall -y iocage-lib iocage-cli
 test:


### PR DESCRIPTION
The Makefile's depends target previously ran "pip install -Ur requirements.txt", which installed all runtime Python dependencies directly into the system Python's site-packages.  This pollutes and can conflict with a pkg-managed installation in /usr/local.

End users install via "pkg install sysutils/iocage" where the ports framework handles dependencies properly.  The developer workflow should match: require dependencies be installed via pkg, and only install iocage itself.

Mixing pip and pkg in the same prefix is a known source of conflicts on FreeBSD.  The FreeBSD-idiomatic approach is to use pkg for dependencies and only use pip for the project being developed.

Changes:
- Replace "pip install -Ur requirements.txt" with "pkg install" of the equivalent FreeBSD packages (py${PYVER}-click, etc.), mirroring the port's RUN_DEPENDS
- Derive PYVER automatically from the Python binary so package names adapt to the installed Python version
- Include py${PYVER}-fastentrypoints as a build dependency (imported by setup.py)
- Use "pip install --no-deps ." instead of "python setup.py install" to prevent pip from pulling dependencies itself
- requirements.txt and setup.py install_requires are unchanged as they remain valid package metadata used by the ports framework

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
