### PR TITLE
Test: mock is part of unittest with Python3

### DIFF
--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -21,7 +21,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import mock
+from unittest import mock
 import pytest
 import iocage_lib.ioc_start as ioc_start
 


### PR DESCRIPTION
This is a trivial change, but it removes the need to install the "mock" compatibility package.  With Python3, this is part of the unittest module and so no additional imports are required.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
