### PR TITLE
Adapt flags for is_flag=True, default=True

### DIFF
--- a/iocage_cli/fstab.py
+++ b/iocage_cli/fstab.py
@@ -45,7 +45,7 @@ __rootcmd__ = True
               help="Replace an entry by index number", nargs=1)
 @click.option("--list", "-l", "action",
               help="Lists the jails fstab.", flag_value="list")
-@click.option("--header", "-h", "-H", is_flag=True, default=True,
+@click.option("--header", "-h", "-H", flag_value=False, default=True,
               help="For scripting, use tabs for separators.")
 def cli(action, fstab_string, jail, header, replace):
     """

--- a/iocage_cli/get.py
+++ b/iocage_cli/get.py
@@ -33,7 +33,7 @@ import iocage_lib.iocage as ioc
     max_content_width=400, ), name='get', help='Gets the specified property.')
 @click.argument('prop', required=True, default='')
 @click.argument('jail', required=True, default='')
-@click.option('--header', '-h', '-H', is_flag=True, default=True,
+@click.option('--header', '-h', '-H', flag_value=False, default=True,
               help='For scripting, use tabs for separators.')
 @click.option('--recursive', '-r', help='Get the specified property for all '
                                         'jails.', flag_value='recursive')

--- a/iocage_cli/list.py
+++ b/iocage_cli/list.py
@@ -36,7 +36,7 @@ import iocage_lib.iocage as ioc
               flag_value="basejail", help="List all basejails.")
 @click.option("--template", "-t", "dataset_type", flag_value="template",
               help="List all templates.")
-@click.option("--header", "-h", "-H", is_flag=True, default=True,
+@click.option("--header", "-h", "-H", flag_value=False, default=True,
               help="For scripting, use tabs for separators.")
 @click.option("--long", "-l", "_long", is_flag=True, default=False,
               help="Show the full uuid and ip4 address.")

--- a/iocage_cli/snaplist.py
+++ b/iocage_cli/snaplist.py
@@ -30,7 +30,7 @@ import iocage_lib.iocage as ioc
 
 
 @click.command(name="snaplist", help="Show snapshots of a specified jail.")
-@click.option("--header", "-h", "-H", is_flag=True, default=True,
+@click.option("--header", "-h", "-H", flag_value=False, default=True,
               help="For scripting, use tabs for separators.")
 @click.option("--long", "-l", "_long", is_flag=True, default=False,
               help="Show the full dataset path for snapshot name.")

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -46,11 +46,11 @@ class IOCList(object):
     """
 
     def __init__(
-        self, lst_type='all', hdr=True, full=False, _sort=None, silent=False,
+        self, lst_type='all', header=True, full=False, _sort=None, silent=False,
         callback=None, plugin=False, quick=False, **kwargs
     ):
         self.list_type = lst_type
-        self.header = hdr
+        self.header = header
         self.full = full
         self.iocjson = iocage_lib.ioc_json.IOCJson()
         self.pool = self.iocjson.pool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click>=6.7
+click>=6.7,!=8.2.2,!=8.3.*
 texttable>=1.2.1
 requests>=2.18.4
 coloredlogs>=9.0


### PR DESCRIPTION
See Issue https://github.com/freebsd/iocage/issues/119 for details

I tested this fix localy with the new click from:

```
$ iocage list -q --header
aegir	ix1|192.168.17.14/24
$ iocage list -q         
+----------+----------------------+
|   NAME   |         IP4          |
+==========+======================+
| aegir    | ix1|192.168.XX.14/24 |
+----------+----------------------+
```

**This does not work for click 8.2.2, 8.3.0, 8.3.1, 8.3.2.** (And FreeBSD right now packages unfortunately 8.3.1)
Patch is available here -> https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295723

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
