### PR TITLE
Fix command line parsing problems

### DIFF
--- a/iocage_cli/df.py
+++ b/iocage_cli/df.py
@@ -35,8 +35,8 @@ import texttable
     "-h",
     "-H",
     is_flag=True,
-    default=True,
-    help="For scripting, use tabs for separators.")
+    default=not ioc.CLICK_WORKAROUND,
+    help="For scripting, no headers and tabs as separators.")
 @click.option(
     "--long",
     "-l",
@@ -53,6 +53,8 @@ import texttable
     help="Sorts the list by the given type")
 def cli(header, _long, _sort):
     """Allows a user to show resource usage of all jails."""
+    if ioc.CLICK_WORKAROUND:
+        header = not header
     table = texttable.Texttable(max_width=0)
     jail_list = ioc.IOCage().df()
 

--- a/iocage_cli/fstab.py
+++ b/iocage_cli/fstab.py
@@ -45,13 +45,15 @@ __rootcmd__ = True
               help="Replace an entry by index number", nargs=1)
 @click.option("--list", "-l", "action",
               help="Lists the jails fstab.", flag_value="list")
-@click.option("--header", "-h", "-H", is_flag=True, default=True,
-              help="For scripting, use tabs for separators.")
+@click.option("--header", "-h", "-H", is_flag=True, default=not ioc.CLICK_WORKAROUND,
+              help="For scripting, no headers and tabs as separators.")
 def cli(action, fstab_string, jail, header, replace):
     """
     Looks for the jail supplied and passes the uuid, path and configuration
     location to manipulate the fstab.
     """
+    if ioc.CLICK_WORKAROUND:
+        header = not header
     index = None if not replace else replace
     _index = False
     add_path = False

--- a/iocage_cli/get.py
+++ b/iocage_cli/get.py
@@ -33,8 +33,8 @@ import iocage_lib.iocage as ioc
     max_content_width=400, ), name='get', help='Gets the specified property.')
 @click.argument('prop', required=True, default='')
 @click.argument('jail', required=True, default='')
-@click.option('--header', '-h', '-H', is_flag=True, default=True,
-              help='For scripting, use tabs for separators.')
+@click.option('--header', '-h', '-H', is_flag=True, default=not ioc.CLICK_WORKAROUND,
+              help='For scripting, no headers and tabs as separators.')
 @click.option('--recursive', '-r', help='Get the specified property for all '
                                         'jails.', flag_value='recursive')
 @click.option('--plugin', '-P',
@@ -58,6 +58,8 @@ import iocage_lib.iocage as ioc
 )
 def cli(prop, _type, _pool, jail, recursive, header, plugin, force):
     """Get a list of jails and print the property."""
+    if ioc.CLICK_WORKAROUND:
+        header = not header
     table = texttable.Texttable(max_width=0)
 
     if _type:

--- a/iocage_cli/list.py
+++ b/iocage_cli/list.py
@@ -36,15 +36,15 @@ import iocage_lib.iocage as ioc
               flag_value="basejail", help="List all basejails.")
 @click.option("--template", "-t", "dataset_type", flag_value="template",
               help="List all templates.")
-@click.option("--header", "-h", "-H", is_flag=True, default=True,
-              help="For scripting, use tabs for separators.")
+@click.option("--header", "-h", "-H", is_flag=True, default=not ioc.CLICK_WORKAROUND,
+              help="For scripting, no headers and tabs as separators.")
 @click.option("--long", "-l", "_long", is_flag=True, default=False,
               help="Show the full uuid and ip4 address.")
 @click.option("--remote", "-R", is_flag=True,
               help="Show remote's available RELEASEs.")
 @click.option("--plugins", "-P", is_flag=True, help="Show available plugins.")
-@click.option("--http", default=True, help="Have --remote use HTTP instead.",
-              is_flag=True)
+@click.option("--http", is_flag=True, default=not ioc.CLICK_WORKAROUND,
+              help="Have --remote not use HTTP.")
 @click.option("--sort", "-s", "_sort", default="name", nargs=1,
               help="Sorts the list by the given type")
 @click.option("--quick", "-q", is_flag=True, default=False,
@@ -54,6 +54,10 @@ import iocage_lib.iocage as ioc
 def cli(dataset_type, header, _long, remote, http, plugins, _sort, quick,
         official):
     """This passes the arg and calls the jail_datasets function."""
+
+    if ioc.CLICK_WORKAROUND:
+        header = not header
+        http = not http
     freebsd_version = ioc_common.checkoutput(["freebsd-version"])
     iocage = ioc.IOCage(skip_jails=True)
 

--- a/iocage_cli/snaplist.py
+++ b/iocage_cli/snaplist.py
@@ -30,8 +30,8 @@ import iocage_lib.iocage as ioc
 
 
 @click.command(name="snaplist", help="Show snapshots of a specified jail.")
-@click.option("--header", "-h", "-H", is_flag=True, default=True,
-              help="For scripting, use tabs for separators.")
+@click.option("--header", "-h", "-H", is_flag=True, default=not ioc.CLICK_WORKAROUND,
+              help="For scripting, no headers and tabs as separators.")
 @click.option("--long", "-l", "_long", is_flag=True, default=False,
               help="Show the full dataset path for snapshot name.")
 @click.option("--sort", "-s", "_sort", default="created", nargs=1,
@@ -39,6 +39,9 @@ import iocage_lib.iocage as ioc
 @click.argument("jail")
 def cli(header, jail, _long, _sort):
     """Allows a user to show resource usage of all jails."""
+
+    if ioc.CLICK_WORKAROUND:
+        header = not header
     table = texttable.Texttable(max_width=0)
     snap_list = ioc.IOCage(jail=jail).snap_list(_long, _sort)
 

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -53,6 +53,13 @@ from iocage_lib.release import Release
 from iocage_lib.snapshot import SnapshotListableResource, Snapshot
 
 
+# Workaround for click bugs and incompatible changes introduced
+# in 8.2.x. Once we can upgrade to click 8.4.1, this and all
+# its consumers can be removed, but places using the workaround
+# need to be changed to use flag_value=False instead of
+# is_flag=True (and change default to True).
+CLICK_WORKAROUND=True
+
 class PoolAndDataset:
 
     def get_pool(self):


### PR DESCRIPTION
This adds a workaround that ensures flags that default to true and have no "off"-variant (like `--header` for "no headers" - yes, the irony) work with all versions of click (at least pre-8.2.0 through 8.4.1).

Fixes #119

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
