### PR TITLE
Fix developer workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,47 @@
 ZPOOL=""
 SERVER=""
 PYTHON?=/usr/local/bin/python3
+GETPYVER=${PYTHON} -c "import sys;\
+  print(str(sys.version_info.major) + str(sys.version_info.minor))"
+DEPS=\
+  py%-build\
+  py%-click\
+  py%-coloredlogs\
+  py%-dnspython\
+  py%-fastentrypoints\
+  py%-gitpython\
+  py%-hatchling\
+  py%-jsonschema\
+  py%-netifaces\
+  py%-pip\
+  py%-pytest\
+  py%-requests\
+  py%-texttable
 
-depends:
-	@(pkg -vv | grep -e "url.*/latest") > /dev/null 2>&1 || (echo "It is advised pkg url is using \"latest\" instead of \"quarterly\" in /etc/pkg/FreeBSD.conf.";)
-	@test -s ${PYTHON} || (echo "Python binary ${PYTHON} not found, iocage will install python3"; pkg install -q -y python3)
-	${PYTHON} -m ensurepip
-	${PYTHON} -m pip install -Ur requirements.txt
-
-install: depends
-	${PYTHON} setup.py install 
-uninstall:
-	${PYTHON} -m pip uninstall -y iocage-lib iocage-cli
-test:
-	pytest --zpool $(ZPOOL) --server $(SERVER)
 help:
+	@echo "    depends"
+	@echo "        Installs dependencies"
 	@echo "    install"
-	@echo "        Installs iocage"
+	@echo "        Install iocage"
 	@echo "    uninstall"
-	@echo "        Removes iocage"
+	@echo "        Remove iocage"
 	@echo "    test"
 	@echo "        Run unit tests with pytest"
+
+depends:
+	@(pkg -vv | grep -e "url.*/latest") > /dev/null 2>&1 || \
+	  echo 'It is advised pkg url is using "latest" instead of'\
+	  '"quarterly" in /etc/pkg/FreeBSD.conf.'
+	@test -s ${PYTHON} || \
+	  (echo "${PYTHON} not found, iocage will install python3";\
+	  pkg install -q -y python3)
+	@${GETPYVER} | xargs -I% -R-1 pkg install -yA ${DEPS}
+
+install: depends
+	${PYTHON} -m pip install .
+
+uninstall:
+	${PYTHON} -m pip uninstall -y iocage
+
+test:
+	pytest --zpool $(ZPOOL) --server $(SERVER)


### PR DESCRIPTION
After landing #124, the developer workflow is broken. This makes it work again.

This also includes input from #115 and the discussions in it and therefore converts the workflow to using system packages matching the currently installed version of python3.

This also moves the help target to the top, making it the default target, so running `make` won't simply start installing packages.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
