### PR TITLE
Improve release artifact generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.version }}
+          path: iocage-${{ inputs.version }}
       - name: "Build documentation"
         uses: ammaraskar/sphinx-action@master
         with:
-          docs-folder: "doc/source/"
+          docs-folder: iocage-${{ inputs.version }}/doc/source/
           build-command: >
             sphinx-build
             -D version=${{ inputs.version }}


### PR DESCRIPTION
Change release tarball, so it contains a directory called `iocage-<release-version>`, which then contains all the release artifacts.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
