### PR TITLE
Patch away kernel module check in freebsd-update

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -25,6 +25,7 @@
 import hashlib
 import logging
 import os
+import re
 import shutil
 import subprocess as su
 import tarfile
@@ -46,6 +47,7 @@ import iocage_lib.ioc_start
 
 from iocage_lib.pools import Pool
 from iocage_lib.dataset import Dataset
+
 
 # taken from tarfile.tar_filter (and _get_filtered_attrs)
 # basically the same, but **without**:
@@ -70,6 +72,7 @@ def untar_release_filter(member, dest_path):
     if new_attrs:
         return member.replace(**new_attrs, deep=False)
     return member
+
 
 class IOCFetch:
 
@@ -906,7 +909,8 @@ class IOCFetch:
 
         if exception_msg:
             iocage_lib.ioc_common.logit(
-                {'level': 'EXCEPTION', 'message': f'Failed to update: {exception_msg}'}
+                {'level': 'EXCEPTION',
+                 'message': f'Failed to update: {exception_msg}'}
             )
 
         su.Popen(cmd).communicate()
@@ -916,7 +920,9 @@ class IOCFetch:
 
             tmp = tempfile.NamedTemporaryFile(delete=False)
             with urllib.request.urlopen(f) as fbsd_update:
-                tmp.write(fbsd_update.read())
+                tmp.write(re.sub("upgrade_check_kmod_ports\n",
+                                 "#upgrade_check_kmod_ports\n",
+                                 fbsd_update.read().decode()).encode())
             tmp.close()
             os.chmod(tmp.name, 0o755)
             fetch_name = tmp.name

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -27,6 +27,7 @@ import fileinput
 import hashlib
 import os
 import pathlib
+import re
 import subprocess as su
 import tempfile
 import urllib.request
@@ -83,14 +84,16 @@ class IOCUpgrade:
             http_proxy_var = 'http_proxy'
         else:
             http_proxy_var = 'HTTP_PROXY'
-        for envvar in [http_proxy_var, 'HTTPS_PROXY', 'HTTP_PROXY_AUTH', 'NO_PROXY']:
+        for envvar in [http_proxy_var, 'HTTPS_PROXY',
+                       'HTTP_PROXY_AUTH', 'NO_PROXY']:
             if os.environ.get(envvar, '') != '':
                 self.upgrade_env[envvar] = os.environ.get(envvar)
 
         self.callback = callback
 
         # symbolic link created on fetch by freebsd-update
-        bd_hash = hashlib.sha256((self.path + '\n').encode('utf-8')).hexdigest()
+        bd_hash = hashlib.sha256(
+            (self.path + '\n').encode('utf-8')).hexdigest()
         self.freebsd_install_link = os.path.join(
             self.path,
             'var/db/freebsd-update', bd_hash + '-install')
@@ -118,10 +121,13 @@ class IOCUpgrade:
                 fbsd_update = fetched_update
             else:
                 f = "https://cgit.freebsd.org/src/plain" \
-                    f"/usr.sbin/freebsd-update/freebsd-update.sh?h=releng/{f_rel}"
+                    f"/usr.sbin/freebsd-update" \
+                    f"/freebsd-update.sh?h=releng/{f_rel}"
                 tmp = tempfile.NamedTemporaryFile(delete=False)
                 with urllib.request.urlopen(f) as http:
-                    tmp.write(http.read())
+                    tmp.write(re.sub("upgrade_check_kmod_ports\n",
+                                     "#upgrade_check_kmod_ports\n",
+                                     http.read().decode()).encode())
                 tmp.close()
                 os.chmod(tmp.name, 0o755)
                 fbsd_update = tmp.name


### PR DESCRIPTION
This is a hack to avoid the slow and annoying check of installed kernel modules, which actually runs on the host system and has no value whatsoever when updating jails.

There should be something done about this in freebsd-update at some point.

Pacified flake8 on the modified files while there.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/freebsd/iocage/blob/master/CONTRIBUTING.md)
